### PR TITLE
Update azure_openai_pipeline.py

### DIFF
--- a/examples/pipelines/providers/azure_openai_pipeline.py
+++ b/examples/pipelines/providers/azure_openai_pipeline.py
@@ -48,7 +48,7 @@ class Pipeline:
             "Content-Type": "application/json",
         }
 
-        url = f"{self.valves.AZURE_OPENAI_ENDPOINT}/openai/deployments/{self.valves.DEPLOYMENT_NAME}/chat/completions?api-version={self.valves.API_VERSION}"
+        url = f"{self.valves.AZURE_OPENAI_ENDPOINT}/openai/deployments/{self.valves.DEPLOYMENT_NAME}/completions?api-version={self.valves.API_VERSION}"
 
         try:
             r = requests.post(


### PR DESCRIPTION
based on Azure's doc:
https://learn.microsoft.com/en-us/azure/ai-services/openai/reference

the url does not have the /chat/ part.