### PR TITLE
Fix Cohere provider `self.id`

### DIFF
--- a/examples/pipelines/providers/cohere_manifold_pipeline.py
+++ b/examples/pipelines/providers/cohere_manifold_pipeline.py
@@ -29,7 +29,8 @@ class Pipeline:
         # Best practice is to not specify the id so that it can be automatically inferred from the filename, so that users can install multiple versions of the same pipeline.
         # The identifier must be unique across all pipelines.
         # The identifier must be an alphanumeric string that can include underscores or hyphens. It cannot contain spaces, special characters, slashes, or backslashes.
-        # self.id = "cohere"
+
+        self.id = "cohere"
 
         self.name = "cohere/"
 


### PR DESCRIPTION
Was commented out for some reason, causes the model IDs to default to `cohere_manifold_pipeline.model_name` which is quite a mouthful, and broke my carefully-crafted model list. I'd like to not edit that again.