### PR TITLE
Fix: OpenAIChatMessage

### DIFF
--- a/schemas.py
+++ b/schemas.py
@@ -4,7 +4,7 @@ from pydantic import BaseModel, ConfigDict
 
 class OpenAIChatMessage(BaseModel):
     role: str
-    content: str
+    content: str | List
 
     model_config = ConfigDict(extra="allow")
 


### PR DESCRIPTION
The content field should be of type "str | List" to conform with the chat/completions api.
Currently this is a problem, as sending a message containing an image to the pipeline causes a 422 "Unprocessable Entity" error.