### PR TITLE
fix: Invalid URL format, surrounding quotes does not match with regex

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -53,6 +53,9 @@ download_pipelines() {
   local path=$1
   local destination=$2
 
+  # Remove any surrounding quotes from the path
+  path=$(echo "$path" | sed 's/^"//;s/"$//')
+
   echo "Downloading pipeline files from $path to $destination..."
 
   if [[ "$path" =~ ^https://github.com/.*/.*/blob/.* ]]; then


### PR DESCRIPTION
The surrounding quotes do not match with the regex in the `start.sh` download.

I encountered this issue when I tried using Docker Compose with the following configuration:
```yaml
environment:
  - PIPELINES_URLS="https://github.com/open-webui/pipelines/blob/main/examples/filters/langfuse_filter_pipeline.py"
```

The quotes caused an error.

```
pipelines     | Invalid URL format: "https://github.com/open-webui/pipelines/blob/main/examples/filters/langfuse_filter_pipeline.py"
```


I checked the Docker image `python:3.11-slim-bookworm` and it includes the `sed` command.



