### PR TITLE
Unified Model Router

### DIFF
--- a/examples/filters/unified_model_router.py
+++ b/examples/filters/unified_model_router.py
@@ -1,0 +1,129 @@
+from typing import List, Optional
+from pydantic import BaseModel
+import json
+import aiohttp
+from utils.pipelines.main import get_last_user_message
+
+class Pipeline:
+    class Valves(BaseModel):
+        pipelines: List[str] = []
+        priority: int = 0
+        openai_base_url: str = "http://host.docker.internal:3000/v1"  # OpenAI Compatible URL
+
+    def __init__(self):
+        self.type = "filter"
+        self.name = "Interception Filter"
+        self.valves = self.Valves(
+            **{
+                "pipelines": ["*"],  # Connect to all pipelines
+            }
+        )
+
+    async def on_startup(self):
+        print(f"on_startup:{__name__}")
+        pass
+
+    async def on_shutdown(self):
+        print(f"on_shutdown:{__name__}")
+        pass
+
+    # Define functions for decision/intent here
+    async def process_image_ollama(self, body: dict, content: str):
+        messages = body.get("messages", [])
+        images = []
+        for message in messages:
+            if "images" in message:
+                print('RUNNING PROCESS IMAGE')
+                images.extend(message["images"])
+                #url = f"{self.valves.openai_base_url}/chat/completions"
+                url = "http://host.docker.internal:11434/api/chat" # Using ollama endpoint here because the openai ollama api doesn't yet support vision
+
+                payload = {
+                    "model": "llava:latest",
+                    "messages": [
+                        {
+                            "role": "user",
+                            "content": content,
+                            "images": images
+                        }
+                    ]
+                }
+
+                async with aiohttp.ClientSession() as session:
+                    async with session.post(url, json=payload) as response:
+                        if response.status == 200:
+                            content = []
+                            async for line in response.content:
+                                data = json.loads(line)
+                                content.append(data.get("message", {}).get("content", ""))
+                            raw_llava_response = "".join(content)
+                            print(raw_llava_response)
+                            llava_response = f"REPEAT THIS BACK: {raw_llava_response}"
+                            print(llava_response)
+                            message["content"] = llava_response
+                            message.pop("images", None)  # This will safely remove the 'images' key if it exists
+    
+    async def process_image_openai(self, body: dict, content: str):
+        messages = body.get("messages", [])
+        images = []
+        for message in messages:
+            if "images" in message:
+                print('RUNNING PROCESS IMAGE')
+                images.extend(message["images"])
+                print(images)
+                # url = f"{self.valves.openai_base_url}/chat/completions"
+                url = "http://host.docker.internal:11434/api/chat" # Using ollama endpoint here because the openai ollama api doesn't yet support vision
+                payload = {
+                    "model": "llava:latest",
+                    "messages": [
+                        {
+                            "role": "user",
+                            "content": content,
+                            "images": images
+                        }
+                    ]
+                }
+
+                async with aiohttp.ClientSession() as session:
+                    async with session.post(url, json=payload) as response:
+                        if response.status == 200:
+                            response_data = await response.json()
+                            choices = response_data.get('choices', [])
+                            if choices:
+                                assistant_message = choices[0].get('message', {}).get('content', '')
+                                print(assistant_message)
+                                llava_response = f"REPEAT THIS BACK: {assistant_message}"
+                                print(llava_response)
+                                message["content"] = llava_response
+                                message.pop("images", None)  # This will safely remove the 'images' key if it exists
+
+
+    # Implement task llm to call for other models in the inlet
+    async def inlet(self, body: dict, user: Optional[dict] = None) -> dict:
+        print(f"pipe:{__name__}")
+
+        # Ensure the body is a dictionary
+        if isinstance(body, str):
+            body = json.loads(body)
+
+        model = body.get("model", "")
+        user_message = get_last_user_message(body["messages"])
+
+        # Dictionary to map intents to their corresponding functions
+        model_functions = {
+            'process an image using Ollama': self.process_image_ollama,
+            'process an image using OpenAI': self.process_image_openai
+        }
+
+        # Function to route to the appropriate model
+        async def model_router(model_to_load, body, user_message):
+            # Get the function from the dictionary, defaulting to a lambda for the default case
+            model_function = model_functions.get(model_to_load)
+            if model_function:
+                await model_function(body, user_message)
+            else:
+                print("Using current user-selected model")
+
+        # Example usage - We will constrain task llm to this output - Don't know how yet
+        await model_router('process an image using Ollama', body, user_message)
+        return body

--- a/examples/filters/unified_model_router.py
+++ b/examples/filters/unified_model_router.py
@@ -35,8 +35,7 @@ class Pipeline:
             if "images" in message:
                 print('RUNNING PROCESS IMAGE')
                 images.extend(message["images"])
-                #url = f"{self.valves.openai_base_url}/chat/completions"
-                url = "http://host.docker.internal:11434/api/chat" # Using ollama endpoint here because the openai ollama api doesn't yet support vision
+                url = "http://host.docker.internal:11434/api/chat"
 
                 payload = {
                     "model": "llava:latest",
@@ -62,6 +61,7 @@ class Pipeline:
                             print(llava_response)
                             message["content"] = llava_response
                             message.pop("images", None)  # This will safely remove the 'images' key if it exists
+                            # TODO: *IMPORTANT* Image is not being removed properly, so router is seeing the image every time.
     
     async def process_image_openai(self, body: dict, content: str):
         messages = body.get("messages", [])
@@ -71,8 +71,7 @@ class Pipeline:
                 print('RUNNING PROCESS IMAGE')
                 images.extend(message["images"])
                 print(images)
-                # url = f"{self.valves.openai_base_url}/chat/completions"
-                url = "http://host.docker.internal:11434/api/chat" # Using ollama endpoint here because the openai ollama api doesn't yet support vision
+                url = f"{self.valves.openai_base_url}/chat/completions"
                 payload = {
                     "model": "llava:latest",
                     "messages": [

--- a/examples/filters/unified_model_router.py
+++ b/examples/filters/unified_model_router.py
@@ -125,5 +125,13 @@ class Pipeline:
                 print("Using current user-selected model")
 
         # Example usage - We will constrain task llm to this output - Don't know how yet
+        # TODO: Determine best 1-3b param model to determine intent
+        # TODO: Determine best way to constrain model output (thinking langchain OllamaFunctions? Will this work with openai endpoints?)
+        #       Instruct models may just be able to be constrained reliably by the prompt
+        # TODO: Implement mechanism (likely before inlet) to allow the LLM to make decision. Likely this will look like a function that
+        #       takes a string and given a matching string executes correcsponding function based on model_functions dictionary
         await model_router('process an image using Ollama', body, user_message)
+
+        # TODO: Decision - Do we want to leave state as is for ollama functions or do we want to always reload the original submittin
+        #                  model? Not sure yet, but probs leave state as is.
         return body

--- a/examples/pipelines/integrations/semantic_model_router.py
+++ b/examples/pipelines/integrations/semantic_model_router.py
@@ -1,0 +1,150 @@
+from typing import List, Union, Generator, Iterator
+from pydantic import BaseModel
+import requests
+import os
+import json
+import aiohttp
+
+class Pipeline:
+    class Valves(BaseModel):
+        pipelines: List[str] = []
+        priority: int = 0
+        openai_base_url: str = "http://host.docker.internal:11434/v1"  # OpenAI Compatible URL
+
+    def __init__(self):
+        self.name = "Semantic Model Router"
+        self.valves = self.Valves(
+            **{
+                "pipelines": ["*"],  # Connect to all pipelines
+            }
+        )
+
+    async def on_startup(self):
+        print(f"on_startup:{__name__}")
+        pass
+
+    async def on_shutdown(self):
+        print(f"on_shutdown:{__name__}")
+        pass
+
+    async def default_chat(self, body: dict, content: str):
+        messages = body.get("messages", [])
+        url = f"{self.valves.openai_base_url}/chat/completions"
+        payload = {
+            "model": "eva",
+            "messages": [
+                {
+                    "role": "user",
+                    "content": content
+                }
+            ]
+        }
+        try:
+            async with aiohttp.ClientSession() as session:
+                async with session.post(url, json=payload) as response:
+                    if response.status == 200:
+                        response_data = await response.json()
+                        choices = response_data.get('choices', [])
+                        if choices:
+                            assistant_message = choices[0].get('message', {}).get('content', '')
+                            print(assistant_message)
+                            formatted_llm_response = f"REPEAT THIS BACK: MODEL - EVA {assistant_message}"
+                            print(formatted_llm_response)
+                            for message in messages:
+                                message["content"] = formatted_llm_response
+        except Exception as e:
+            print(f"Error in default_chat: {e}")
+
+    async def media_chat(self, body: dict, content: str):
+        messages = body.get("messages", [])
+        url = f"{self.valves.openai_base_url}/chat/completions"
+        payload = {
+            "model": "llama3:instruct",
+            "messages": [
+                {
+                    "role": "user",
+                    "content": content
+                }
+            ]
+        }
+        try:
+            async with aiohttp.ClientSession() as session:
+                async with session.post(url, json=payload) as response:
+                    if response.status == 200:
+                        response_data = await response.json()
+                        choices = response_data.get('choices', [])
+                        if choices:
+                            assistant_message = choices[0].get('message', {}).get('content', '')
+                            print(assistant_message)
+                            formatted_llm_response = f"REPEAT THIS BACK: MODEL - llama3:latest {assistant_message}"
+                            print(formatted_llm_response)
+                            for message in messages:
+                                message["content"] = formatted_llm_response
+        except Exception as e:
+            print(f"Error in media_chat: {e}")
+
+    def determine_intention(self, user_message: str) -> str:
+
+        intentions = {
+            'general_chatting()': 'The user is simply chatting with you and asking simple questions.',
+            'media()': 'The user is asking about an image/picture/video',
+        }
+
+        url = f"{self.valves.openai_base_url}/chat/completions"
+        payload = {
+            "model": "gemma:2b-instruct-v1.1-q4_K_M",
+            "messages": [
+                {
+                    "role": "user",
+                    "content": f"""
+                    <system_prompt>
+                    You are an intention measurement machine. You will consider the USER_QUERY carefully and decide what their intention is.
+                    You may select one of the following intentions from the object below:
+
+                    {intentions}
+
+                    <start_of_turn>user
+                    USER_QUERY: 
+                    {user_message}
+                    <end_of_turn>
+                    <start_of_turn>
+                    YOU WILL RESPOND WITH ONLY A SINGLE WORD - The intention key value
+                    model 
+                    """
+                }
+            ]
+        }
+        try:
+            response = requests.post(url, json=payload)
+            print('REQUESTING!')
+            if response.status == 200:
+                response_data = response.json()
+                choices = response_data.get('choices', [])
+                if choices:
+                    return choices[0].get('message', {}).get('content', '').strip()
+        except Exception as e:
+            print(f"Error in determine_intention: {e}")
+        return ""
+
+    def pipe(
+        self, user_message: str, model_id: str, messages: List[dict], body: dict
+    ) -> Union[str, Generator, Iterator]:
+        print(f"pipe:{__name__}")
+
+        intention_response = self.determine_intention(user_message)
+        print(intention_response)
+
+        # Check intention conditions
+        if 'media_chat()' in intention_response:
+            self.media_chat(body, user_message)
+        elif 'default_chat()' in intention_response:
+            self.default_chat(body, user_message)
+
+        # Ensure the body is a dictionary
+        if isinstance(body, str):
+            body = json.loads(body)
+
+        model = body.get("model", "")
+        print(f"MODEL: {model}")
+
+        return body


### PR DESCRIPTION
Haven't yet implemented LLM decision logic, but as it stands we can still filter for static cases and execute code or route to LLMs based on matching cases!

Went ahead and PRed this as it's useful even in its current state.

Right now the example statically sets the Ollama image processing use case so it's functionality is identical to the dynamic image processing pipeline, but there are two example. Once for OpenAI compatible endpoints and one for Ollama endpoints.

Should make it very easy for anyone to basically copy paste and with minimal effort create their own model re-routes.

This example effectively replaces the dynamic image processing pipeline with a more robust solution.

Obviously improvements will definitely come to this.