### PR TITLE
fix: anthropic_manifold_pipeline.py system_message

### DIFF
--- a/examples/pipelines/providers/anthropic_manifold_pipeline.py
+++ b/examples/pipelines/providers/anthropic_manifold_pipeline.py
@@ -99,7 +99,7 @@ class Pipeline:
             **{
                 "model": model_id,
                 **(
-                    {"system": system_message} if system_message else {}
+                    {"system": system_message["content"]} if system_message else {}
                 ),  # Add system message if it exists (optional
                 "messages": messages,
                 "max_tokens": max_tokens,
@@ -134,7 +134,7 @@ class Pipeline:
             **{
                 "model": model_id,
                 **(
-                    {"system": system_message} if system_message else {}
+                    {"system": system_message["content"]} if system_message else {}
                 ),  # Add system message if it exists (optional
                 "messages": messages,
                 "max_tokens": max_tokens,


### PR DESCRIPTION
Relates to: https://github.com/open-webui/pipelines/pull/109

With a system message anthropic example does not work and gives error:
```
anthropic.BadRequestError: Error code: 400 - {'type': 'error', 'error': {'type': 'invalid_request_error', 'message': 'system.0: Input does not match the expected shape.'}}
```

Reason is that system should just be a string instead of the object `get_system_message` returns. See documentation here: https://docs.anthropic.com/en/docs/build-with-claude/prompt-engineering/system-prompts#how-to-give-claude-a-role

With this change it works fine.