### PR TITLE
feat: Update Ollama manifold pipeline to use environment variable for base URL

### DIFF
--- a/examples/pipelines/providers/ollama_manifold_pipeline.py
+++ b/examples/pipelines/providers/ollama_manifold_pipeline.py
@@ -1,5 +1,7 @@
 from typing import List, Union, Generator, Iterator
 from schemas import OpenAIChatMessage
+import os
+
 from pydantic import BaseModel
 import requests
 
@@ -24,7 +26,11 @@ class Pipeline:
         # Optionally, you can set the name of the manifold pipeline.
         self.name = "Ollama: "
 
-        self.valves = self.Valves(**{"OLLAMA_BASE_URL": "http://localhost:11435"})
+        self.valves = self.Valves(
+            **{
+                "OLLAMA_BASE_URL": os.getenv("OLLAMA_BASE_URL", "http://localhost:11435"),
+            }
+        )
         self.pipelines = []
         pass
 


### PR DESCRIPTION
I wanted to be able to configure the pipeline in the same way [examples/filters/langfuse_filter_pipeline.py](https://github.com/open-webui/pipelines/blob/9cf0fc4e506838045b1660d1d00ced03841b506f/examples/filters/langfuse_filter_pipeline.py) does it.

Added the use of an env var for the pipeline example for [examples/pipelines/providers/ollama_manifold_pipeline.py](https://github.com/open-webui/pipelines/blob/9cf0fc4e506838045b1660d1d00ced03841b506f/examples/pipelines/providers/ollama_manifold_pipeline.py).

Change is backwards compatible, as it defaults to the same as before.