### PR TITLE
refactor(examples/azure_openai_pipeline): make use of env variables and prefixed with a consistent prefix to avoid conflicts

### DIFF
--- a/examples/pipelines/providers/azure_openai_pipeline.py
+++ b/examples/pipelines/providers/azure_openai_pipeline.py
@@ -6,10 +6,10 @@ import requests
 class Pipeline:
     class Valves(BaseModel):
         # You can add your custom valves here.
-        AZURE_OPENAI_API_KEY: str = "your-azure-openai-api-key-here"
-        AZURE_OPENAI_ENDPOINT: str = "your-azure-openai-endpoint-here"
-        DEPLOYMENT_NAME: str = "your-deployment-name-here"
-        API_VERSION: str = "2024-02-01"
+        AZURE_OPENAI_API_KEY: str
+        AZURE_OPENAI_ENDPOINT: str
+        AZURE_OPENAI_DEPLOYMENT_NAME: str
+        AZURE_OPENAI_API_VERSION: str
 
     def __init__(self):
         # Optionally, you can set the id and name of the pipeline.
@@ -18,7 +18,14 @@ class Pipeline:
         # The identifier must be an alphanumeric string that can include underscores or hyphens. It cannot contain spaces, special characters, slashes, or backslashes.
         # self.id = "azure_openai_pipeline"
         self.name = "Azure OpenAI Pipeline"
-        self.valves = self.Valves()
+        self.valves = self.Valves(
+            **{
+                "AZURE_OPENAI_API_KEY": os.getenv("AZURE_OPENAI_API_KEY", "your-azure-openai-api-key-here"),
+                "AZURE_OPENAI_ENDPOINT": os.getenv("AZURE_OPENAI_ENDPOINT", "your-azure-openai-endpoint-here"),
+                "AZURE_OPENAI_DEPLOYMENT_NAME": os.getenv("AZURE_OPENAI_DEPLOYMENT_NAME", "your-deployment-name-here"),
+                "AZURE_OPENAI_API_VERSION": os.getenv("AZURE_OPENAI_API_VERSION", "2024-02-01"),
+            }
+        )
         pass
 
     async def on_startup(self):


### PR DESCRIPTION
BREAKING CHANGE: all valves are now prefixed with `AZURE_OPENAI_`.