### PR TITLE
add a LangGraph example via FastAPI 20240715

### DIFF
--- a/examples/pipelines/providers/langgraph_pipeline/REAEME.md
+++ b/examples/pipelines/providers/langgraph_pipeline/REAEME.md
@@ -1,0 +1,4 @@
+To use `LangGraph` or `LangChain` in openwebui-pipelines, we can
+1. Build a chain or agent through `LangGraph` or `LangChain`, as described in [langgraph_agent.py](./langgraph_agent.py)
+2. Create a web service for chain or agent through `FastAPI`, as described in [fastapi_server.py](./fastapi_server.py)
+3. Call FastAPI API in pipelines to get chain or agent results through `requests`, as described in [pipelines.py](./pipelines.py)

--- a/examples/pipelines/providers/langgraph_pipeline/fastapi_server.py
+++ b/examples/pipelines/providers/langgraph_pipeline/fastapi_server.py
@@ -1,0 +1,29 @@
+from langgraph_agent import graph, State
+
+from fastapi import FastAPI, Request, Response
+from fastapi.responses import StreamingResponse
+from fastapi.middleware.cors import CORSMiddleware
+
+app = FastAPI(
+    title="API for openwebui-pipelines",
+    description="API for openwebui-pipelines",
+    )
+
+@app.post("/openwebui-pipelines/api")
+async def main(inputs: State):
+    async def event_stream():
+        async for event in graph.astream_events(input = inputs
+                                                ,version="v2"
+                                                ):
+            kind = event["event"]
+            if  kind == "on_chat_model_stream" or kind=="on_chain_stream":
+                content = event["data"]["chunk"]
+                if content:
+                    yield content
+
+    return StreamingResponse(event_stream(), media_type="text/event-stream")
+
+if __name__ == "__main__":
+    import uvicorn
+
+    uvicorn.run(app, host="0.0.0.0", port=8510)

--- a/examples/pipelines/providers/langgraph_pipeline/langgraph_agent.py
+++ b/examples/pipelines/providers/langgraph_pipeline/langgraph_agent.py
@@ -1,0 +1,21 @@
+from typing import Annotated
+from typing_extensions import TypedDict
+from langgraph.graph import StateGraph, START, END
+from langgraph.graph.message import add_messages
+from langchain_anthropic import ChatAnthropic
+
+class State(TypedDict):
+    messages: Annotated[list, add_messages]
+
+llm = ChatAnthropic(model="claude-3-haiku-20240307")
+
+def chatbot(state: State):
+    return {"messages": [llm.invoke(state["messages"])]}
+
+graph_builder = StateGraph(State)
+graph_builder.add_node("chatbot", chatbot)
+graph_builder.add_edge(START, "chatbot")
+graph_builder.add_edge("chatbot", END)
+
+
+graph = graph_builder.compile()

--- a/examples/pipelines/providers/langgraph_pipeline/pipelines.py
+++ b/examples/pipelines/providers/langgraph_pipeline/pipelines.py
@@ -1,0 +1,45 @@
+import requests
+from typing import List, Union, Generator, Iterator
+try:
+    from pydantic.v1 import BaseModel
+except Exception:
+    from pydantic import BaseModel
+
+
+
+class Pipeline:
+
+    class Valves(BaseModel):
+        pass
+
+    def __init__(self):
+        self.id = "LangGraph Agent"
+        self.name = "LangGraph Agent"
+
+    async def on_startup(self):
+        print(f"on_startup: {__name__}")
+        pass
+
+    async def on_shutdown(self):
+        print(f"on_shutdown: {__name__}")
+        pass
+
+    def pipe(
+        self, user_message: str, model_id: str, messages: List[dict], body: dict
+            ) -> Union[str, Generator, Iterator]:
+        
+        url = 'http://localhost:8510/openwebui-pipelines/api'
+        headers = {
+            'accept': 'application/json',
+            'Content-Type': 'application/json'
+        }
+        data = {
+            "messages": [[msg['role'], msg['content']] for msg  in messages]
+            }
+
+        response = requests.post(url, json=data, headers=headers, stream=True)
+        for line in response.iter_lines():
+            if line:
+                yield line.decode() + '\n'
+
+


### PR DESCRIPTION
To use LangGraph or LangChain, we build a FastAPI web service.Then we can call this service in openwebui-pipelines