### PR TITLE
schemas.py fix to support image input with latest open WebUI version

### DIFF
--- a/schemas.py
+++ b/schemas.py
@@ -1,22 +1,12 @@
-from typing import List, Union, Optional
-from pydantic import BaseModel, RootModel, ConfigDict
-
-class ImageContent(BaseModel):
-    type: str
-    image_url: dict
-
-class TextContent(BaseModel):
-    type: str
-    text: str
-
-class MessageContent(RootModel):
-    root: Union[TextContent, ImageContent]
+from typing import List, Optional
+from pydantic import BaseModel, ConfigDict
 
 class OpenAIChatMessage(BaseModel):
     role: str
-    content: Union[str, List[MessageContent]]
+    content: str | List
 
     model_config = ConfigDict(extra="allow")
+
 
 class OpenAIChatCompletionForm(BaseModel):
     stream: bool = True
@@ -24,6 +14,7 @@ class OpenAIChatCompletionForm(BaseModel):
     messages: List[OpenAIChatMessage]
 
     model_config = ConfigDict(extra="allow")
+
 
 class FilterForm(BaseModel):
     body: dict


### PR DESCRIPTION
With latest Open WebUI version it is not any more needed to split content to image and text content:

``` python
class ImageContent(BaseModel):
    type: str
    image_url: dict

class TextContent(BaseModel):
    type: str
    text: str
```

Old implementation can be again used. Tested with Azure OpenAI service GPT-4o model. 