### PR TITLE
Add Presidio PII Redaction Filter

### DIFF
--- a/examples/filters/presidio_filter_pipeline.py
+++ b/examples/filters/presidio_filter_pipeline.py
@@ -1,0 +1,81 @@
+"""
+title: Presidio PII Redaction Pipeline
+author: justinh-rahb
+date: 2024-07-07
+version: 0.1.0
+license: MIT
+description: A pipeline for redacting personally identifiable information (PII) using the Presidio library.
+requirements: presidio-analyzer, presidio-anonymizer
+"""
+
+import os
+from typing import List, Optional
+from pydantic import BaseModel
+from schemas import OpenAIChatMessage
+from presidio_analyzer import AnalyzerEngine
+from presidio_anonymizer import AnonymizerEngine
+from presidio_anonymizer.entities import OperatorConfig
+
+class Pipeline:
+    class Valves(BaseModel):
+        pipelines: List[str] = ["*"]
+        priority: int = 0
+        enabled_for_admins: bool = False
+        entities_to_redact: List[str] = [
+            "PERSON", "EMAIL_ADDRESS", "PHONE_NUMBER", "US_SSN", 
+            "CREDIT_CARD", "IP_ADDRESS", "US_PASSPORT", "LOCATION",
+            "DATE_TIME", "NRP", "MEDICAL_LICENSE", "URL"
+        ]
+        language: str = "en"
+
+    def __init__(self):
+        self.type = "filter"
+        self.name = "Presidio PII Redaction Pipeline"
+
+        self.valves = self.Valves(
+            **{
+                "pipelines": os.getenv("PII_REDACT_PIPELINES", "*").split(","),
+                "enabled_for_admins": os.getenv("PII_REDACT_ENABLED_FOR_ADMINS", "false").lower() == "true",
+                "entities_to_redact": os.getenv("PII_REDACT_ENTITIES", ",".join(self.Valves().entities_to_redact)).split(","),
+                "language": os.getenv("PII_REDACT_LANGUAGE", "en"),
+            }
+        )
+
+        self.analyzer = AnalyzerEngine()
+        self.anonymizer = AnonymizerEngine()
+
+    async def on_startup(self):
+        print(f"on_startup:{__name__}")
+
+    async def on_shutdown(self):
+        print(f"on_shutdown:{__name__}")
+
+    def redact_pii(self, text: str) -> str:
+        results = self.analyzer.analyze(
+            text=text,
+            language=self.valves.language,
+            entities=self.valves.entities_to_redact
+        )
+
+        anonymized_text = self.anonymizer.anonymize(
+            text=text,
+            analyzer_results=results,
+            operators={
+                "DEFAULT": OperatorConfig("replace", {"new_value": "[REDACTED]"})
+            }
+        )
+
+        return anonymized_text.text
+
+    async def inlet(self, body: dict, user: Optional[dict] = None) -> dict:
+        print(f"pipe:{__name__}")
+        print(body)
+        print(user)
+
+        if user is None or user.get("role") != "admin" or self.valves.enabled_for_admins:
+            messages = body.get("messages", [])
+            for message in messages:
+                if message.get("role") == "user":
+                    message["content"] = self.redact_pii(message["content"])
+
+        return body


### PR DESCRIPTION
## Introducing the Presidio PII Redaction Filter

This PR presents a robust enhancement to data privacy with the **Presidio PII Redaction Filter**, now implemented in: `presidio_filter_pipeline.py`. This filter is designed to streamline the identification and redaction of sensitive Personally Identifiable Information (PII) from text data.

![download](https://github.com/user-attachments/assets/25aa4402-c6c0-40ed-ae5a-1d47ec067455)

**PII Redaction Features:**

- The filter automatically detects a wide variety of PII entities, ensuring compliance with data protection regulations.
- Supported entities include:
  - `PERSON`
  - `EMAIL_ADDRESS`
  - `PHONE_NUMBER`
  - `US_SSN`
  - `CREDIT_CARD`
  - `IP_ADDRESS`
  - `US_PASSPORT`
  - `LOCATION`
  - `DATE_TIME`
  - `NRP` (National Reference Point)
  - `MEDICAL_LICENSE`
  - `URL`

**Pipeline Configuration Options:**

- **Pipelines:** Specifies which underlying machine learning models to leverage for the PII detection, with a customizable list: 
  - Example:
  ```
  cohere.c4ai-aya-23,cohere.command-r-plus,google_gen_ai.gemini-1.5-flash-latest
  ```
  
- **Priority:** Set the processing priority for this filter (default is 0), allowing users to manage the order of execution in multi-pipeline configurations.

- **Enable for Admins:** The filter can be toggled on/off specifically for admin use, providing flexibility in access control.

- **Language Support:** Adjust the language setting (default is English) to enhance PII detection accuracy in different linguistic contexts.

---

This enhancement to the Pipelines framework provides a comprehensive solution for PII handling, enabling organizations to protect sensitive information efficiently while maintaining flexibility in their data processing workflows.