### PR TITLE
Adding ability to install requirements from frontmatter through the /pipelines/add API

### DIFF
--- a/main.py
+++ b/main.py
@@ -26,6 +26,7 @@ import time
 import json
 import uuid
 import sys
+import subprocess
 
 
 from config import API_KEY, PIPELINES_DIR


### PR DESCRIPTION
Solves the issue #188 

Issue: The frontmatter "requirements" field is not respected when pipeline is added through the /pipelines/add API, which is what OpenWebUI uses.

Solution: As part of loading the module, extract frontmatter, run `pip` to install the requirements before loading the module.

This should match the behavior similar to what start.sh doesn.