### PR TITLE
Use native system instructions for Gemini 1.5 models

### DIFF
--- a/examples/pipelines/providers/google_manifold_pipeline.py
+++ b/examples/pipelines/providers/google_manifold_pipeline.py
@@ -125,11 +125,14 @@ class Pipeline:
                             "role": "user" if message["role"] == "user" else "model",
                             "parts": [{"text": message["content"]}]
                         })
-
-            if system_message:
-                contents.insert(0, {"role": "user", "parts": [{"text": f"System: {system_message}"}]})
-
-            model = genai.GenerativeModel(model_name=model_id)
+            
+            if "gemini-1.5" in model_id:
+                model = genai.GenerativeModel(model_name=model_id, system_instruction=system_message)
+            else:
+                if system_message:
+                    contents.insert(0, {"role": "user", "parts": [{"text": f"System: {system_message}"}]})
+                
+                model = genai.GenerativeModel(model_name=model_id)
 
             generation_config = GenerationConfig(
                 temperature=body.get("temperature", 0.7),

--- a/examples/pipelines/providers/google_manifold_pipeline.py
+++ b/examples/pipelines/providers/google_manifold_pipeline.py
@@ -2,7 +2,7 @@
 title: Google GenAI Manifold Pipeline
 author: Marc Lopez (refactor by justinh-rahb)
 date: 2024-06-06
-version: 1.2
+version: 1.3
 license: MIT
 description: A pipeline for generating text using Google's GenAI models in Open-WebUI.
 requirements: google-generativeai


### PR DESCRIPTION
The current code in `google_manifold_pipeline` adds a "system"-like prompt by prepending the request with a message containing the system prompt:

```py
if system_message:
    contents.insert(0, {"role": "user", "parts": [{"text": f"System: {system_message}"}]})
```

On Gemini 1.5 models, Google added support for native system instructions. In the Python API it is passed as an argument for the constructor:

```py
model = genai.GenerativeModel(model_name=model_id, system_instruction=system_message)
```

The equivalent in the REST API is documented [here](https://ai.google.dev/gemini-api/docs/system-instructions?lang=rest):
```
curl https://generativelanguage.googleapis.com/v1beta/models/gemini-1.5-flash:generateContent?key=$GOOGLE_API_KEY \
-H 'Content-Type: application/json' \
-d '{ "system_instruction": {
    "parts":
      { "text": "You are Neko the cat respond like one"}},
    "contents": {
      "parts": {
        "text": "Good morning! How are you?"}}}'
```

In my patch I added support for it when the string `gemini-1.5` is part of the model id:

```py
            if "gemini-1.5" in model_id:
                model = genai.GenerativeModel(model_name=model_id, system_instruction=system_message)
            else:
                if system_message:
                    contents.insert(0, {"role": "user", "parts": [{"text": f"System: {system_message}"}]})
                
                model = genai.GenerativeModel(model_name=model_id)
```

Gemini 1.0 and Gemma models don't support system instructions, so they will fall back to the other approach. **Note**: after trying to use `system_instruction` with Gemini 1.0 I got an error from the server, but both Gemma models (`gemma2-9b-it` and `gemma-7b-it`) did accept the instruction without error and showed knowledge of it. Officially they [don't support system instructions](https://ai.google.dev/gemma/docs/formatting#system-instructions), so it could be a workaround prompt on the server.

Future models, say, like `gemini-2.0` will need to be added manually when they become available on the API, otherwise they will fall back to the other approach. 

The information returned by the API unfortunately doesn't indicate if the model supports system instructions. Here is for example, the information for Gemini 1.5 pro (returned via `https://generativelanguage.googleapis.com/v1beta/models`):
```json
   {
      "name": "models/gemini-1.5-pro",
      "version": "001",
      "displayName": "Gemini 1.5 Pro",
      "description": "Mid-size multimodal model that supports up to 2 million tokens",
      "inputTokenLimit": 2097152,
      "outputTokenLimit": 8192,
      "supportedGenerationMethods": [
        "generateContent",
        "countTokens"
      ],
      "temperature": 1,
      "topP": 0.95,
      "topK": 64,
      "maxTemperature": 2
    },
```