### PR TITLE
Fix: Get LiteLLM Models

### DIFF
--- a/examples/pipelines/providers/litellm_manifold_pipeline.py
+++ b/examples/pipelines/providers/litellm_manifold_pipeline.py
@@ -53,6 +53,8 @@ class Pipeline:
     async def on_startup(self):
         # This function is called when the server is started.
         print(f"on_startup:{__name__}")
+        # Get models on startup
+        self.pipelines = self.get_litellm_models()
         pass
 
     async def on_shutdown(self):

--- a/examples/pipelines/providers/litellm_manifold_pipeline.py
+++ b/examples/pipelines/providers/litellm_manifold_pipeline.py
@@ -2,7 +2,7 @@
 title: LiteLLM Manifold Pipeline
 author: open-webui
 date: 2024-05-30
-version: 1.0
+version: 1.0.1
 license: MIT
 description: A manifold pipeline that uses LiteLLM.
 """
@@ -46,7 +46,8 @@ class Pipeline:
                 "LITELLM_PIPELINE_DEBUG": os.getenv("LITELLM_PIPELINE_DEBUG", False),
             }
         )
-        self.pipelines = []
+        # Get models on initialization
+        self.pipelines = self.get_litellm_models()
         pass
 
     async def on_startup(self):
@@ -85,7 +86,7 @@ class Pipeline:
                     for model in models["data"]
                 ]
             except Exception as e:
-                print(f"Error: {e}")
+                print(f"Error fetching models from LiteLLM: {e}")
                 return [
                     {
                         "id": "error",
@@ -93,6 +94,7 @@ class Pipeline:
                     },
                 ]
         else:
+            print("LITELLM_BASE_URL not set. Please configure it in the valves.")
             return []
 
     def pipe(


### PR DESCRIPTION
## Fix: Populate LiteLLM Manifold Model List on Initialization

This PR addresses an issue where the LiteLLM Manifold pipeline wasn't fetching the model list on startup, causing the pipelines list to remain empty until the valves were manually saved.

The solution is to call the `get_litellm_models()` function within the `__init__` method of the `Pipeline` class. This ensures that the model list is retrieved from the LiteLLM server as soon as the pipeline is initialized.

**Key Changes:**

- Added a call to `get_litellm_models()` within the `__init__` method.
- Improved error handling in `get_litellm_models()` to provide more informative messages.
- Added a print statement when `LITELLM_BASE_URL` is not set.

**Benefits:**

- The model list is now populated on startup, providing a smoother user experience.
- Users no longer need to manually save the valves to see the available models.
- Enhanced error handling provides clearer feedback in case of issues fetching models.

**Addresses:**

- #111 

**Acknowledgement:**
@attilaszasz for the same fix from the Gemini manifold (#193) applied here.