### PR TITLE
Fix: Initialize request object, correct typo, and rename parameter in Azure OpenAI Pipe

### DIFF
--- a/examples/pipelines/providers/azure_openai_pipeline.py
+++ b/examples/pipelines/providers/azure_openai_pipeline.py
@@ -56,8 +56,8 @@ class Pipeline:
         url = f"{self.valves.AZURE_OPENAI_ENDPOINT}/openai/deployments/{self.valves.AZURE_OPENAI_DEPLOYMENT_NAME}/chat/completions?api-version={self.valves.AZURE_OPENAI_API_VERSION}"
 
         allowed_params = {'messages', 'temperature', 'role', 'content', 'contentPart', 'contentPartImage',
-                          'enhancements', 'dataSources', 'n', 'stream', 'stop', 'max_tokens', 'presence_penalty',
-                          'frequency_penalty', 'logit_bias', 'user', 'function_call', 'funcions', 'tools',
+                          'enhancements', 'data_sources', 'n', 'stream', 'stop', 'max_tokens', 'presence_penalty',
+                          'frequency_penalty', 'logit_bias', 'user', 'function_call', 'functions', 'tools',
                           'tool_choice', 'top_p', 'log_probs', 'top_logprobs', 'response_format', 'seed'}
         # remap user field
         if "user" in body and not isinstance(body["user"], str):
@@ -67,6 +67,8 @@ class Pipeline:
         if len(body) != len(filtered_body):
             print(f"Dropped params: {', '.join(set(body.keys()) - set(filtered_body.keys()))}")
 
+        # Initialize the response variable to None.
+        r = None
         try:
             r = requests.post(
                 url=url,


### PR DESCRIPTION
This PR addresses the issues identified in the Azure OpenAI Pipe code and references #244:

1. Initialization of Request Object 
The requests response object `r` is now initialized to `None` to prevent a `NameError` in the exception handling block if an error occurs before `r` is defined.

2. Typo Correction
The typo in the `allowed_params` set has been corrected from `funcions` to `functions` as referenced in the documentation.

3. Parameter Renaming:
The parameter `dataSources` has been renamed to `data_sources` in the `allowed_params` set as also referenced in the [documentation](https://learn.microsoft.com/en-us/azure/ai-services/openai/reference-preview#request-body-2).