### PR TITLE
feat: track user.email in langfuse filter pipeline and remove wrong token count

### DIFF
--- a/examples/filters/langfuse_filter_pipeline.py
+++ b/examples/filters/langfuse_filter_pipeline.py
@@ -2,7 +2,7 @@
 title: Langfuse Filter Pipeline
 author: open-webui
 date: 2024-05-30
-version: 1.1
+version: 1.2
 license: MIT
 description: A filter pipeline that uses Langfuse.
 requirements: langfuse
@@ -90,8 +90,8 @@ class Pipeline:
         trace = self.langfuse.trace(
             name=f"filter:{__name__}",
             input=body,
-            user_id=user["id"],
-            metadata={"name": user["name"]},
+            user_id=user["email"],
+            metadata={"user_name": user["name"], "user_id": user["id"]},
             session_id=body["chat_id"],
         )
 
@@ -119,10 +119,6 @@ class Pipeline:
 
         generation.end(
             output=generated_message,
-            usage={
-                "totalCost": (len(user_message) + len(generated_message)) / 1000,
-                "unit": "CHARACTERS",
-            },
             metadata={"interface": "open-webui"},
         )
 


### PR DESCRIPTION
This change logs the user.email to langfuse as user_id. This makes langfuse much more useful as it allows to easily map usage to a certain person with the organization using openwebui.

Also I removed the logging of characters to Langfuse as this is wrong for almost all models. I'd love to add token tracking but were not able to figure out were openwebui tracks token counts. I'll create an issue for this on the main repo.

cc @samuelpetermoshi who suggested this