### PR TITLE
build: smaller container image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,2 +1,5 @@
 .venv
 .env
+.git
+.github
+Dockerfile

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,11 @@
-FROM python:3.11-slim-bookworm as base
+FROM python:3.11-slim-bookworm AS base
 
 # Use args
 ARG USE_CUDA
 ARG USE_CUDA_VER
 
-## Basis ##
-ENV ENV=prod \
-    PORT=9099 \
-    # pass build args to the build
-    USE_CUDA_DOCKER=${USE_CUDA} \
+# Pass build args to the build
+ENV USE_CUDA_DOCKER=${USE_CUDA} \
     USE_CUDA_DOCKER_VER=${USE_CUDA_VER}
 
 
@@ -30,11 +27,17 @@ RUN pip3 install uv && \
     fi
 RUN uv pip install --system -r requirements.txt --no-cache-dir
 
-# Copy the application code
+FROM python:3.11-slim-bookworm AS final
+# Copy installed dependencies
+COPY --from=base /usr/local/lib/python3.11/site-packages /usr/local/lib/python3.11/site-packages
+COPY --from=base /usr/local/include /usr/local/include
+COPY --from=base /usr/local/bin /usr/local/bin
 COPY . .
 
 # Expose the port
 ENV HOST="0.0.0.0"
 ENV PORT="9099"
+ENV ENV=prod
+ENV PORT=9099
 
 ENTRYPOINT [ "bash", "start.sh" ]


### PR DESCRIPTION
## What changed

This PR uses multi-stage builds to reduce the container image size.

The container build file now copies all installed (and possibly compiled) dependencies to the final layer without keeping the build tools.

Not included in the final image are
 * gcc build-essential curl git
 * build-caches manpages
 * .git .github Dockerfile

Uncompressed size difference: `4.37GB`  vs `3.79GB`. A reduction of 600MB that dont have to be stored and transfered over the network anymore.

## Tests
Ich created a file based diff after each image layer and compared the changed files. All changed files that are needed are still copied over to the final image. 

I stated the image build with and without the `USE_CUDA_DOCKER`. The resulting image started with no problem