### PR TITLE
Add module to sys.modules after loading for use with @dataclass

### DIFF
--- a/main.py
+++ b/main.py
@@ -145,6 +145,7 @@ async def load_module_from_path(module_name, module_path):
         # Load the module
         spec = importlib.util.spec_from_file_location(module_name, module_path)
         module = importlib.util.module_from_spec(spec)
+        sys.modules[module_name] = module
         spec.loader.exec_module(module)
         print(f"Loaded module: {module.__name__}")
         if hasattr(module, "Pipeline"):


### PR DESCRIPTION
I ran into an issue with trying to use `@dataclass` within a pipeline resulted in an exception with the following:

```
AttributeError: 'NoneType' object has no attribute '__dict__'.
```

This PR seems to fix it on my fork!