### PR TITLE
Do not print body in rate_limit_filter_pipeline

### DIFF
--- a/examples/filters/rate_limit_filter_pipeline.py
+++ b/examples/filters/rate_limit_filter_pipeline.py
@@ -115,8 +115,6 @@ class Pipeline:
 
     async def inlet(self, body: dict, user: Optional[dict] = None) -> dict:
         print(f"pipe:{__name__}")
-        print(body)
-        print(user)
 
         if user.get("role", "admin") == "user":
             user_id = user["id"] if user and "id" in user else "default_user"


### PR DESCRIPTION
This PR removes logging the variable "body" and "user". These contains userinfo and full conversation respectively. Logging them always without any control is not best practice.