### PR TITLE
Consolidate GH Actions

### DIFF
--- a/.github/workflows/build-docker-image.yaml
+++ b/.github/workflows/build-docker-image.yaml
@@ -1,0 +1,120 @@
+name: Build Docker Image
+
+on:
+    workflow_call:
+        inputs:
+            build_args:
+                required: false
+                default: ""
+                type: string
+            cache_id:
+                required: true
+                type: string
+            extract_flavor:
+                required: false
+                default: ""
+                type: string
+            image_name:
+                required: true
+                type: string
+            image_tag:
+                required: false
+                default: ""
+                type: string
+            registry:
+                required: false
+                default: ghcr.io
+                type: string
+
+env:
+    FULL_IMAGE_NAME: ${{ inputs.registry }}/${{ inputs.image_name }}
+
+jobs:
+    build-image:
+        runs-on: ubuntu-latest
+        permissions:
+            contents: read
+            packages: write
+        strategy:
+            fail-fast: false
+            matrix:
+                platform:
+                    - linux/amd64
+                    - linux/arm64
+
+        steps:
+            - name: Prepare
+              run: |
+                  platform=${{ matrix.platform }}
+                  echo "PLATFORM_PAIR=${platform//\//-}" >> $GITHUB_ENV
+
+            - name: Checkout repository
+              uses: actions/checkout@v4
+
+            - name: Set up QEMU
+              uses: docker/setup-qemu-action@v3
+
+            - name: Set up Docker Buildx
+              uses: docker/setup-buildx-action@v3
+
+            - name: Log in to the Container registry
+              uses: docker/login-action@v3
+              with:
+                  registry: ${{ inputs.registry }}
+                  username: ${{ github.actor }}
+                  password: ${{ secrets.GITHUB_TOKEN }}
+
+            - name: Extract metadata for Docker images
+              id: meta
+              uses: docker/metadata-action@v5
+              with:
+                  images: ${{ env.FULL_IMAGE_NAME }}
+                  tags: |
+                      type=ref,event=branch
+                      type=ref,event=tag
+                      type=sha,prefix=git-
+                      type=semver,pattern={{version}}
+                      type=semver,pattern={{major}}.{{minor}}
+                      ${{ inputs.image_tag }}
+                  flavor: |
+                      latest=${{ github.ref == 'refs/heads/main' }}
+                      ${{ inputs.extract_flavor }}
+
+            - name: Extract metadata for Docker cache
+              id: cache-meta
+              uses: docker/metadata-action@v5
+              with:
+                  images: ${{ env.FULL_IMAGE_NAME }}
+                  tags: |
+                      type=ref,event=branch
+                  flavor: |
+                      prefix=cache-${{ inputs.cache_id }}-${{ matrix.platform }}-
+
+            - name: Build Docker image
+              uses: docker/build-push-action@v5
+              id: build
+              with:
+                  context: .
+                  push: true
+                  platforms: ${{ matrix.platform }}
+                  labels: ${{ steps.meta.outputs.labels }}
+                  outputs: type=image,name=${{ env.FULL_IMAGE_NAME }},push-by-digest=true,name-canonical=true,push=true
+                  cache-from: type=registry,ref=${{ steps.cache-meta.outputs.tags }}
+                  cache-to: type=registry,ref=${{ steps.cache-meta.outputs.tags }},mode=max
+                  build-args: |
+                      BUILD_HASH=${{ github.sha }}
+                      ${{ inputs.build_args }}
+
+            - name: Export digest
+              run: |
+                  mkdir -p /tmp/digests
+                  digest="${{ steps.build.outputs.digest }}"
+                  touch "/tmp/digests/${digest#sha256:}"
+
+            - name: Upload digest
+              uses: actions/upload-artifact@v4
+              with:
+                  name: digests-${{ inputs.cache_id }}-${{ env.PLATFORM_PAIR }}
+                  path: /tmp/digests/*
+                  if-no-files-found: error
+                  retention-days: 1

--- a/.github/workflows/docker-build.yaml
+++ b/.github/workflows/docker-build.yaml
@@ -6,273 +6,41 @@ on:
         branches:
             - main
             - dev
-            - tweaks
 
 env:
-    REGISTRY: ghcr.io
+    CUDA_IMAGE_TAG: type=raw,enable=${{ github.ref == 'refs/heads/main' }},prefix=,suffix=,value=cuda
+    CUDA_IMAGE_FLAVOR: suffix=-cuda,onlatest=true
     IMAGE_NAME: ${{ github.repository }}
-    FULL_IMAGE_NAME: ghcr.io/${{ github.repository }}
 
 jobs:
     build-main-image:
-        runs-on: ubuntu-latest
-        permissions:
-            contents: read
-            packages: write
-        strategy:
-            fail-fast: false
-            matrix:
-                platform:
-                    - linux/amd64
-                    - linux/arm64
-
-        steps:
-            - name: Prepare
-              run: |
-                  platform=${{ matrix.platform }}
-                  echo "PLATFORM_PAIR=${platform//\//-}" >> $GITHUB_ENV
-
-            - name: Checkout repository
-              uses: actions/checkout@v4
-
-            - name: Set up QEMU
-              uses: docker/setup-qemu-action@v3
-
-            - name: Set up Docker Buildx
-              uses: docker/setup-buildx-action@v3
-
-            - name: Log in to the Container registry
-              uses: docker/login-action@v3
-              with:
-                  registry: ${{ env.REGISTRY }}
-                  username: ${{ github.actor }}
-                  password: ${{ secrets.GITHUB_TOKEN }}
-
-            - name: Extract metadata for Docker images (default latest tag)
-              id: meta
-              uses: docker/metadata-action@v5
-              with:
-                  images: ${{ env.FULL_IMAGE_NAME }}
-                  tags: |
-                      type=ref,event=branch
-                      type=ref,event=tag
-                      type=sha,prefix=git-
-                      type=semver,pattern={{version}}
-                      type=semver,pattern={{major}}.{{minor}}
-                  flavor: |
-                      latest=${{ github.ref == 'refs/heads/main' }}
-
-            - name: Extract metadata for Docker cache
-              id: cache-meta
-              uses: docker/metadata-action@v5
-              with:
-                  images: ${{ env.FULL_IMAGE_NAME }}
-                  tags: |
-                      type=ref,event=branch
-                  flavor: |
-                      prefix=cache-${{ matrix.platform }}-
-
-            - name: Build Docker image (latest)
-              uses: docker/build-push-action@v5
-              id: build
-              with:
-                  context: .
-                  push: true
-                  platforms: ${{ matrix.platform }}
-                  labels: ${{ steps.meta.outputs.labels }}
-                  outputs: type=image,name=${{ env.FULL_IMAGE_NAME }},push-by-digest=true,name-canonical=true,push=true
-                  cache-from: type=registry,ref=${{ steps.cache-meta.outputs.tags }}
-                  cache-to: type=registry,ref=${{ steps.cache-meta.outputs.tags }},mode=max
-                  build-args: |
-                      BUILD_HASH=${{ github.sha }}
-
-            - name: Export digest
-              run: |
-                  mkdir -p /tmp/digests
-                  digest="${{ steps.build.outputs.digest }}"
-                  touch "/tmp/digests/${digest#sha256:}"
-
-            - name: Upload digest
-              uses: actions/upload-artifact@v4
-              with:
-                  name: digests-main-${{ env.PLATFORM_PAIR }}
-                  path: /tmp/digests/*
-                  if-no-files-found: error
-                  retention-days: 1
+        uses: ./.github/workflows/build-docker-image.yaml
+        with:
+            image_name: ${{ env.IMAGE_NAME }}
+            cache_id: main
 
     build-cuda-image:
-        runs-on: ubuntu-latest
-        permissions:
-            contents: read
-            packages: write
-        strategy:
-            fail-fast: false
-            matrix:
-                platform:
-                    - linux/amd64
-                    - linux/arm64
-
-        steps:
-            - name: Prepare
-              run: |
-                  platform=${{ matrix.platform }}
-                  echo "PLATFORM_PAIR=${platform//\//-}" >> $GITHUB_ENV
-
-            - name: Checkout repository
-              uses: actions/checkout@v4
-
-            - name: Set up QEMU
-              uses: docker/setup-qemu-action@v3
-
-            - name: Set up Docker Buildx
-              uses: docker/setup-buildx-action@v3
-
-            - name: Log in to the Container registry
-              uses: docker/login-action@v3
-              with:
-                  registry: ${{ env.REGISTRY }}
-                  username: ${{ github.actor }}
-                  password: ${{ secrets.GITHUB_TOKEN }}
-
-            - name: Extract metadata for Docker images (cuda tag)
-              id: meta
-              uses: docker/metadata-action@v5
-              with:
-                  images: ${{ env.FULL_IMAGE_NAME }}
-                  tags: |
-                      type=ref,event=branch
-                      type=ref,event=tag
-                      type=sha,prefix=git-
-                      type=semver,pattern={{version}}
-                      type=semver,pattern={{major}}.{{minor}}
-                      type=raw,enable=${{ github.ref == 'refs/heads/main' }},prefix=,suffix=,value=cuda
-                  flavor: |
-                      latest=${{ github.ref == 'refs/heads/main' }}
-                      suffix=-cuda,onlatest=true
-
-            - name: Extract metadata for Docker cache
-              id: cache-meta
-              uses: docker/metadata-action@v5
-              with:
-                  images: ${{ env.FULL_IMAGE_NAME }}
-                  tags: |
-                      type=ref,event=branch
-                  flavor: |
-                      prefix=cache-cuda-${{ matrix.platform }}-
-
-            - name: Build Docker image (cuda)
-              uses: docker/build-push-action@v5
-              id: build
-              with:
-                  context: .
-                  push: true
-                  platforms: ${{ matrix.platform }}
-                  labels: ${{ steps.meta.outputs.labels }}
-                  outputs: type=image,name=${{ env.FULL_IMAGE_NAME }},push-by-digest=true,name-canonical=true,push=true
-                  cache-from: type=registry,ref=${{ steps.cache-meta.outputs.tags }}
-                  cache-to: type=registry,ref=${{ steps.cache-meta.outputs.tags }},mode=max
-                  build-args: |
-                      BUILD_HASH=${{ github.sha }}
-                      USE_CUDA=true
-
-            - name: Export digest
-              run: |
-                  mkdir -p /tmp/digests
-                  digest="${{ steps.build.outputs.digest }}"
-                  touch "/tmp/digests/${digest#sha256:}"
-
-            - name: Upload digest
-              uses: actions/upload-artifact@v4
-              with:
-                  name: digests-cuda-${{ env.PLATFORM_PAIR }}
-                  path: /tmp/digests/*
-                  if-no-files-found: error
-                  retention-days: 1
+        uses: ./.github/workflows/build-docker-image.yaml
+        with:
+            image_name: ${{ env.IMAGE_NAME }}
+            cache_id: cuda
+            image_tag: ${{ env.CUDA_IMAGE_TAG }}
+            extract_flavor: ${{ env.CUDA_IMAGE_FLAVOR }}
+            build_args: |
+                USE_CUDA=true
 
     merge-main-images:
-        runs-on: ubuntu-latest
+        uses: ./.github/workflows/merge-docker-images.yaml
         needs: [build-main-image]
-        steps:
-            - name: Download digests
-              uses: actions/download-artifact@v4
-              with:
-                  pattern: digests-main-*
-                  path: /tmp/digests
-                  merge-multiple: true
-
-            - name: Set up Docker Buildx
-              uses: docker/setup-buildx-action@v3
-
-            - name: Log in to the Container registry
-              uses: docker/login-action@v3
-              with:
-                  registry: ${{ env.REGISTRY }}
-                  username: ${{ github.actor }}
-                  password: ${{ secrets.GITHUB_TOKEN }}
-
-            - name: Extract metadata for Docker images (default latest tag)
-              id: meta
-              uses: docker/metadata-action@v5
-              with:
-                  images: ${{ env.FULL_IMAGE_NAME }}
-                  tags: |
-                      type=ref,event=branch
-                      type=ref,event=tag
-                      type=sha,prefix=git-
-                  flavor: |
-                      latest=${{ github.ref == 'refs/heads/main' }}
-
-            - name: Create manifest list and push
-              working-directory: /tmp/digests
-              run: |
-                  docker buildx imagetools create $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
-                    $(printf '${{ env.FULL_IMAGE_NAME }}@sha256:%s ' *)
-
-            - name: Inspect image
-              run: |
-                  docker buildx imagetools inspect ${{ env.FULL_IMAGE_NAME }}:${{ steps.meta.outputs.version }}
+        with:
+            image_name: ${{ env.IMAGE_NAME }}
+            cache_id: main
 
     merge-cuda-images:
-        runs-on: ubuntu-latest
+        uses: ./.github/workflows/merge-docker-images.yaml
         needs: [build-cuda-image]
-        steps:
-            - name: Download digests
-              uses: actions/download-artifact@v4
-              with:
-                  pattern: digests-cuda-*
-                  path: /tmp/digests
-                  merge-multiple: true
-
-            - name: Set up Docker Buildx
-              uses: docker/setup-buildx-action@v3
-
-            - name: Log in to the Container registry
-              uses: docker/login-action@v3
-              with:
-                  registry: ${{ env.REGISTRY }}
-                  username: ${{ github.actor }}
-                  password: ${{ secrets.GITHUB_TOKEN }}
-
-            - name: Extract metadata for Docker images (default latest tag)
-              id: meta
-              uses: docker/metadata-action@v5
-              with:
-                  images: ${{ env.FULL_IMAGE_NAME }}
-                  tags: |
-                      type=ref,event=branch
-                      type=ref,event=tag
-                      type=sha,prefix=git-
-                      type=raw,enable=${{ github.ref == 'refs/heads/main' }},prefix=,suffix=,value=cuda
-                  flavor: |
-                      latest=${{ github.ref == 'refs/heads/main' }}
-                      suffix=-cuda,onlatest=true
-
-            - name: Create manifest list and push
-              working-directory: /tmp/digests
-              run: |
-                  docker buildx imagetools create $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
-                    $(printf '${{ env.FULL_IMAGE_NAME }}@sha256:%s ' *)
-
-            - name: Inspect image
-              run: |
-                  docker buildx imagetools inspect ${{ env.FULL_IMAGE_NAME }}:${{ steps.meta.outputs.version }}
+        with:
+            image_name: ${{ env.IMAGE_NAME }}
+            cache_id: cuda
+            extract_flavor: ${{ env.CUDA_IMAGE_FLAVOR }}
+            extract_tags: ${{ env.CUDA_IMAGE_TAG }}

--- a/.github/workflows/docker-build.yaml
+++ b/.github/workflows/docker-build.yaml
@@ -1,277 +1,278 @@
 name: Create and publish Docker images with specific build args
 
 on:
-  workflow_dispatch:
-  push:
-    branches:
-      - main
-      - dev
+    workflow_dispatch:
+    push:
+        branches:
+            - main
+            - dev
+            - tweaks
 
 env:
-  REGISTRY: ghcr.io
-  IMAGE_NAME: ${{ github.repository }}
-  FULL_IMAGE_NAME: ghcr.io/${{ github.repository }}
+    REGISTRY: ghcr.io
+    IMAGE_NAME: ${{ github.repository }}
+    FULL_IMAGE_NAME: ghcr.io/${{ github.repository }}
 
 jobs:
-  build-main-image:
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      packages: write
-    strategy:
-      fail-fast: false
-      matrix:
-        platform:
-          - linux/amd64
-          - linux/arm64
+    build-main-image:
+        runs-on: ubuntu-latest
+        permissions:
+            contents: read
+            packages: write
+        strategy:
+            fail-fast: false
+            matrix:
+                platform:
+                    - linux/amd64
+                    - linux/arm64
 
-    steps:
-      - name: Prepare
-        run: |
-          platform=${{ matrix.platform }}
-          echo "PLATFORM_PAIR=${platform//\//-}" >> $GITHUB_ENV
+        steps:
+            - name: Prepare
+              run: |
+                  platform=${{ matrix.platform }}
+                  echo "PLATFORM_PAIR=${platform//\//-}" >> $GITHUB_ENV
 
-      - name: Checkout repository
-        uses: actions/checkout@v4
+            - name: Checkout repository
+              uses: actions/checkout@v4
 
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+            - name: Set up QEMU
+              uses: docker/setup-qemu-action@v3
 
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+            - name: Set up Docker Buildx
+              uses: docker/setup-buildx-action@v3
 
-      - name: Log in to the Container registry
-        uses: docker/login-action@v3
-        with:
-          registry: ${{ env.REGISTRY }}
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+            - name: Log in to the Container registry
+              uses: docker/login-action@v3
+              with:
+                  registry: ${{ env.REGISTRY }}
+                  username: ${{ github.actor }}
+                  password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Extract metadata for Docker images (default latest tag)
-        id: meta
-        uses: docker/metadata-action@v5
-        with:
-          images: ${{ env.FULL_IMAGE_NAME }}
-          tags: |
-            type=ref,event=branch
-            type=ref,event=tag
-            type=sha,prefix=git-
-            type=semver,pattern={{version}}
-            type=semver,pattern={{major}}.{{minor}}
-          flavor: |
-            latest=${{ github.ref == 'refs/heads/main' }}
+            - name: Extract metadata for Docker images (default latest tag)
+              id: meta
+              uses: docker/metadata-action@v5
+              with:
+                  images: ${{ env.FULL_IMAGE_NAME }}
+                  tags: |
+                      type=ref,event=branch
+                      type=ref,event=tag
+                      type=sha,prefix=git-
+                      type=semver,pattern={{version}}
+                      type=semver,pattern={{major}}.{{minor}}
+                  flavor: |
+                      latest=${{ github.ref == 'refs/heads/main' }}
 
-      - name: Extract metadata for Docker cache
-        id: cache-meta
-        uses: docker/metadata-action@v5
-        with:
-          images: ${{ env.FULL_IMAGE_NAME }}
-          tags: |
-            type=ref,event=branch
-          flavor: |
-            prefix=cache-${{ matrix.platform }}-
+            - name: Extract metadata for Docker cache
+              id: cache-meta
+              uses: docker/metadata-action@v5
+              with:
+                  images: ${{ env.FULL_IMAGE_NAME }}
+                  tags: |
+                      type=ref,event=branch
+                  flavor: |
+                      prefix=cache-${{ matrix.platform }}-
 
-      - name: Build Docker image (latest)
-        uses: docker/build-push-action@v5
-        id: build
-        with:
-          context: .
-          push: true
-          platforms: ${{ matrix.platform }}
-          labels: ${{ steps.meta.outputs.labels }}
-          outputs: type=image,name=${{ env.FULL_IMAGE_NAME }},push-by-digest=true,name-canonical=true,push=true
-          cache-from: type=registry,ref=${{ steps.cache-meta.outputs.tags }}
-          cache-to: type=registry,ref=${{ steps.cache-meta.outputs.tags }},mode=max
-          build-args: |
-            BUILD_HASH=${{ github.sha }}
+            - name: Build Docker image (latest)
+              uses: docker/build-push-action@v5
+              id: build
+              with:
+                  context: .
+                  push: true
+                  platforms: ${{ matrix.platform }}
+                  labels: ${{ steps.meta.outputs.labels }}
+                  outputs: type=image,name=${{ env.FULL_IMAGE_NAME }},push-by-digest=true,name-canonical=true,push=true
+                  cache-from: type=registry,ref=${{ steps.cache-meta.outputs.tags }}
+                  cache-to: type=registry,ref=${{ steps.cache-meta.outputs.tags }},mode=max
+                  build-args: |
+                      BUILD_HASH=${{ github.sha }}
 
-      - name: Export digest
-        run: |
-          mkdir -p /tmp/digests
-          digest="${{ steps.build.outputs.digest }}"
-          touch "/tmp/digests/${digest#sha256:}"
+            - name: Export digest
+              run: |
+                  mkdir -p /tmp/digests
+                  digest="${{ steps.build.outputs.digest }}"
+                  touch "/tmp/digests/${digest#sha256:}"
 
-      - name: Upload digest
-        uses: actions/upload-artifact@v4
-        with:
-          name: digests-main-${{ env.PLATFORM_PAIR }}
-          path: /tmp/digests/*
-          if-no-files-found: error
-          retention-days: 1
+            - name: Upload digest
+              uses: actions/upload-artifact@v4
+              with:
+                  name: digests-main-${{ env.PLATFORM_PAIR }}
+                  path: /tmp/digests/*
+                  if-no-files-found: error
+                  retention-days: 1
 
-  build-cuda-image:
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      packages: write
-    strategy:
-      fail-fast: false
-      matrix:
-        platform:
-          - linux/amd64
-          - linux/arm64
+    build-cuda-image:
+        runs-on: ubuntu-latest
+        permissions:
+            contents: read
+            packages: write
+        strategy:
+            fail-fast: false
+            matrix:
+                platform:
+                    - linux/amd64
+                    - linux/arm64
 
-    steps:
-      - name: Prepare
-        run: |
-          platform=${{ matrix.platform }}
-          echo "PLATFORM_PAIR=${platform//\//-}" >> $GITHUB_ENV
+        steps:
+            - name: Prepare
+              run: |
+                  platform=${{ matrix.platform }}
+                  echo "PLATFORM_PAIR=${platform//\//-}" >> $GITHUB_ENV
 
-      - name: Checkout repository
-        uses: actions/checkout@v4
+            - name: Checkout repository
+              uses: actions/checkout@v4
 
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+            - name: Set up QEMU
+              uses: docker/setup-qemu-action@v3
 
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+            - name: Set up Docker Buildx
+              uses: docker/setup-buildx-action@v3
 
-      - name: Log in to the Container registry
-        uses: docker/login-action@v3
-        with:
-          registry: ${{ env.REGISTRY }}
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+            - name: Log in to the Container registry
+              uses: docker/login-action@v3
+              with:
+                  registry: ${{ env.REGISTRY }}
+                  username: ${{ github.actor }}
+                  password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Extract metadata for Docker images (cuda tag)
-        id: meta
-        uses: docker/metadata-action@v5
-        with:
-          images: ${{ env.FULL_IMAGE_NAME }}
-          tags: |
-            type=ref,event=branch
-            type=ref,event=tag
-            type=sha,prefix=git-
-            type=semver,pattern={{version}}
-            type=semver,pattern={{major}}.{{minor}}
-            type=raw,enable=${{ github.ref == 'refs/heads/main' }},prefix=,suffix=,value=cuda
-          flavor: |
-            latest=${{ github.ref == 'refs/heads/main' }}
-            suffix=-cuda,onlatest=true
+            - name: Extract metadata for Docker images (cuda tag)
+              id: meta
+              uses: docker/metadata-action@v5
+              with:
+                  images: ${{ env.FULL_IMAGE_NAME }}
+                  tags: |
+                      type=ref,event=branch
+                      type=ref,event=tag
+                      type=sha,prefix=git-
+                      type=semver,pattern={{version}}
+                      type=semver,pattern={{major}}.{{minor}}
+                      type=raw,enable=${{ github.ref == 'refs/heads/main' }},prefix=,suffix=,value=cuda
+                  flavor: |
+                      latest=${{ github.ref == 'refs/heads/main' }}
+                      suffix=-cuda,onlatest=true
 
-      - name: Extract metadata for Docker cache
-        id: cache-meta
-        uses: docker/metadata-action@v5
-        with:
-          images: ${{ env.FULL_IMAGE_NAME }}
-          tags: |
-            type=ref,event=branch
-          flavor: |
-            prefix=cache-cuda-${{ matrix.platform }}-
+            - name: Extract metadata for Docker cache
+              id: cache-meta
+              uses: docker/metadata-action@v5
+              with:
+                  images: ${{ env.FULL_IMAGE_NAME }}
+                  tags: |
+                      type=ref,event=branch
+                  flavor: |
+                      prefix=cache-cuda-${{ matrix.platform }}-
 
-      - name: Build Docker image (cuda)
-        uses: docker/build-push-action@v5
-        id: build
-        with:
-          context: .
-          push: true
-          platforms: ${{ matrix.platform }}
-          labels: ${{ steps.meta.outputs.labels }}
-          outputs: type=image,name=${{ env.FULL_IMAGE_NAME }},push-by-digest=true,name-canonical=true,push=true
-          cache-from: type=registry,ref=${{ steps.cache-meta.outputs.tags }}
-          cache-to: type=registry,ref=${{ steps.cache-meta.outputs.tags }},mode=max
-          build-args: |
-            BUILD_HASH=${{ github.sha }}
-            USE_CUDA=true
+            - name: Build Docker image (cuda)
+              uses: docker/build-push-action@v5
+              id: build
+              with:
+                  context: .
+                  push: true
+                  platforms: ${{ matrix.platform }}
+                  labels: ${{ steps.meta.outputs.labels }}
+                  outputs: type=image,name=${{ env.FULL_IMAGE_NAME }},push-by-digest=true,name-canonical=true,push=true
+                  cache-from: type=registry,ref=${{ steps.cache-meta.outputs.tags }}
+                  cache-to: type=registry,ref=${{ steps.cache-meta.outputs.tags }},mode=max
+                  build-args: |
+                      BUILD_HASH=${{ github.sha }}
+                      USE_CUDA=true
 
-      - name: Export digest
-        run: |
-          mkdir -p /tmp/digests
-          digest="${{ steps.build.outputs.digest }}"
-          touch "/tmp/digests/${digest#sha256:}"
+            - name: Export digest
+              run: |
+                  mkdir -p /tmp/digests
+                  digest="${{ steps.build.outputs.digest }}"
+                  touch "/tmp/digests/${digest#sha256:}"
 
-      - name: Upload digest
-        uses: actions/upload-artifact@v4
-        with:
-          name: digests-cuda-${{ env.PLATFORM_PAIR }}
-          path: /tmp/digests/*
-          if-no-files-found: error
-          retention-days: 1
+            - name: Upload digest
+              uses: actions/upload-artifact@v4
+              with:
+                  name: digests-cuda-${{ env.PLATFORM_PAIR }}
+                  path: /tmp/digests/*
+                  if-no-files-found: error
+                  retention-days: 1
 
-  merge-main-images:
-    runs-on: ubuntu-latest
-    needs: [build-main-image]
-    steps:
-      - name: Download digests
-        uses: actions/download-artifact@v4
-        with:
-          pattern: digests-main-*
-          path: /tmp/digests
-          merge-multiple: true
+    merge-main-images:
+        runs-on: ubuntu-latest
+        needs: [build-main-image]
+        steps:
+            - name: Download digests
+              uses: actions/download-artifact@v4
+              with:
+                  pattern: digests-main-*
+                  path: /tmp/digests
+                  merge-multiple: true
 
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+            - name: Set up Docker Buildx
+              uses: docker/setup-buildx-action@v3
 
-      - name: Log in to the Container registry
-        uses: docker/login-action@v3
-        with:
-          registry: ${{ env.REGISTRY }}
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+            - name: Log in to the Container registry
+              uses: docker/login-action@v3
+              with:
+                  registry: ${{ env.REGISTRY }}
+                  username: ${{ github.actor }}
+                  password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Extract metadata for Docker images (default latest tag)
-        id: meta
-        uses: docker/metadata-action@v5
-        with:
-          images: ${{ env.FULL_IMAGE_NAME }}
-          tags: |
-            type=ref,event=branch
-            type=ref,event=tag
-            type=sha,prefix=git-
-          flavor: |
-            latest=${{ github.ref == 'refs/heads/main' }}
+            - name: Extract metadata for Docker images (default latest tag)
+              id: meta
+              uses: docker/metadata-action@v5
+              with:
+                  images: ${{ env.FULL_IMAGE_NAME }}
+                  tags: |
+                      type=ref,event=branch
+                      type=ref,event=tag
+                      type=sha,prefix=git-
+                  flavor: |
+                      latest=${{ github.ref == 'refs/heads/main' }}
 
-      - name: Create manifest list and push
-        working-directory: /tmp/digests
-        run: |
-          docker buildx imagetools create $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
-            $(printf '${{ env.FULL_IMAGE_NAME }}@sha256:%s ' *)
+            - name: Create manifest list and push
+              working-directory: /tmp/digests
+              run: |
+                  docker buildx imagetools create $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
+                    $(printf '${{ env.FULL_IMAGE_NAME }}@sha256:%s ' *)
 
-      - name: Inspect image
-        run: |
-          docker buildx imagetools inspect ${{ env.FULL_IMAGE_NAME }}:${{ steps.meta.outputs.version }}
+            - name: Inspect image
+              run: |
+                  docker buildx imagetools inspect ${{ env.FULL_IMAGE_NAME }}:${{ steps.meta.outputs.version }}
 
-  merge-cuda-images:
-    runs-on: ubuntu-latest
-    needs: [build-cuda-image]
-    steps:
-      - name: Download digests
-        uses: actions/download-artifact@v4
-        with:
-          pattern: digests-cuda-*
-          path: /tmp/digests
-          merge-multiple: true
+    merge-cuda-images:
+        runs-on: ubuntu-latest
+        needs: [build-cuda-image]
+        steps:
+            - name: Download digests
+              uses: actions/download-artifact@v4
+              with:
+                  pattern: digests-cuda-*
+                  path: /tmp/digests
+                  merge-multiple: true
 
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+            - name: Set up Docker Buildx
+              uses: docker/setup-buildx-action@v3
 
-      - name: Log in to the Container registry
-        uses: docker/login-action@v3
-        with:
-          registry: ${{ env.REGISTRY }}
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+            - name: Log in to the Container registry
+              uses: docker/login-action@v3
+              with:
+                  registry: ${{ env.REGISTRY }}
+                  username: ${{ github.actor }}
+                  password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Extract metadata for Docker images (default latest tag)
-        id: meta
-        uses: docker/metadata-action@v5
-        with:
-          images: ${{ env.FULL_IMAGE_NAME }}
-          tags: |
-            type=ref,event=branch
-            type=ref,event=tag
-            type=sha,prefix=git-
-            type=raw,enable=${{ github.ref == 'refs/heads/main' }},prefix=,suffix=,value=cuda
-          flavor: |
-            latest=${{ github.ref == 'refs/heads/main' }}
-            suffix=-cuda,onlatest=true
+            - name: Extract metadata for Docker images (default latest tag)
+              id: meta
+              uses: docker/metadata-action@v5
+              with:
+                  images: ${{ env.FULL_IMAGE_NAME }}
+                  tags: |
+                      type=ref,event=branch
+                      type=ref,event=tag
+                      type=sha,prefix=git-
+                      type=raw,enable=${{ github.ref == 'refs/heads/main' }},prefix=,suffix=,value=cuda
+                  flavor: |
+                      latest=${{ github.ref == 'refs/heads/main' }}
+                      suffix=-cuda,onlatest=true
 
-      - name: Create manifest list and push
-        working-directory: /tmp/digests
-        run: |
-          docker buildx imagetools create $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
-            $(printf '${{ env.FULL_IMAGE_NAME }}@sha256:%s ' *)
+            - name: Create manifest list and push
+              working-directory: /tmp/digests
+              run: |
+                  docker buildx imagetools create $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
+                    $(printf '${{ env.FULL_IMAGE_NAME }}@sha256:%s ' *)
 
-      - name: Inspect image
-        run: |
-          docker buildx imagetools inspect ${{ env.FULL_IMAGE_NAME }}:${{ steps.meta.outputs.version }}
+            - name: Inspect image
+              run: |
+                  docker buildx imagetools inspect ${{ env.FULL_IMAGE_NAME }}:${{ steps.meta.outputs.version }}

--- a/.github/workflows/docker-build.yaml
+++ b/.github/workflows/docker-build.yaml
@@ -7,25 +7,20 @@ on:
             - main
             - dev
 
-env:
-    CUDA_IMAGE_TAG: type=raw,enable=${{ github.ref == 'refs/heads/main' }},prefix=,suffix=,value=cuda
-    CUDA_IMAGE_FLAVOR: suffix=-cuda,onlatest=true
-    IMAGE_NAME: ${{ github.repository }}
-
 jobs:
     build-main-image:
         uses: ./.github/workflows/build-docker-image.yaml
         with:
-            image_name: ${{ env.IMAGE_NAME }}
+            image_name: ${{ github.repository }}
             cache_id: main
 
     build-cuda-image:
         uses: ./.github/workflows/build-docker-image.yaml
         with:
-            image_name: ${{ env.IMAGE_NAME }}
+            image_name: ${{ github.repository }}
             cache_id: cuda
-            image_tag: ${{ env.CUDA_IMAGE_TAG }}
-            extract_flavor: ${{ env.CUDA_IMAGE_FLAVOR }}
+            image_tag: type=raw,enable=${{ github.ref == 'refs/heads/main' }},prefix=,suffix=,value=cuda
+            extract_flavor: suffix=-cuda,onlatest=true
             build_args: |
                 USE_CUDA=true
 
@@ -33,14 +28,14 @@ jobs:
         uses: ./.github/workflows/merge-docker-images.yaml
         needs: [build-main-image]
         with:
-            image_name: ${{ env.IMAGE_NAME }}
+            image_name: ${{ github.repository }}
             cache_id: main
 
     merge-cuda-images:
         uses: ./.github/workflows/merge-docker-images.yaml
         needs: [build-cuda-image]
         with:
-            image_name: ${{ env.IMAGE_NAME }}
+            image_name: ${{ github.repository }}
             cache_id: cuda
-            extract_flavor: ${{ env.CUDA_IMAGE_FLAVOR }}
-            extract_tags: ${{ env.CUDA_IMAGE_TAG }}
+            extract_flavor: suffix=-cuda,onlatest=true
+            extract_tags: type=raw,enable=${{ github.ref == 'refs/heads/main' }},prefix=,suffix=,value=cuda

--- a/.github/workflows/merge-docker-images.yaml
+++ b/.github/workflows/merge-docker-images.yaml
@@ -1,0 +1,71 @@
+name: Merge Docker Images
+
+on:
+    workflow_call:
+        inputs:
+            cache_id:
+                required: true
+                type: string
+            extract_flavor:
+                required: false
+                default: ""
+                type: string
+            extract_tags:
+                required: false
+                default: ""
+                type: string
+            image_name:
+                required: true
+                type: string
+            registry:
+                required: false
+                default: ghcr.io
+                type: string
+
+env:
+    FULL_IMAGE_NAME: ${{ inputs.registry }}/${{ inputs.image_name }}
+
+jobs:
+    merge-images:
+        runs-on: ubuntu-latest
+        steps:
+            - name: Download digests
+              uses: actions/download-artifact@v4
+              with:
+                  pattern: digests-${{ inputs.cache_id }}-*
+                  path: /tmp/digests
+                  merge-multiple: true
+
+            - name: Set up Docker Buildx
+              uses: docker/setup-buildx-action@v3
+
+            - name: Log in to the Container registry
+              uses: docker/login-action@v3
+              with:
+                  registry: ${{ inputs.registry }}
+                  username: ${{ github.actor }}
+                  password: ${{ secrets.GITHUB_TOKEN }}
+
+            - name: Extract metadata for Docker images
+              id: meta
+              uses: docker/metadata-action@v5
+              with:
+                  images: ${{ env.FULL_IMAGE_NAME }}
+                  tags: |
+                      type=ref,event=branch
+                      type=ref,event=tag
+                      type=sha,prefix=git-
+                      ${{ inputs.extract_tags }}
+                  flavor: |
+                      latest=${{ github.ref == 'refs/heads/main' }}
+                      ${{ inputs.extract_flavor }}
+
+            - name: Create manifest list and push
+              working-directory: /tmp/digests
+              run: |
+                  docker buildx imagetools create $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
+                    $(printf '${{ env.FULL_IMAGE_NAME }}@sha256:%s ' *)
+
+            - name: Inspect image
+              run: |
+                  docker buildx imagetools inspect ${{ env.FULL_IMAGE_NAME }}:${{ steps.meta.outputs.version }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.11-slim-bookworm as base
+FROM python:3.11-slim-bookworm AS base
 
 # Use args
 ARG USE_CUDA


### PR DESCRIPTION
This pull request streamlines the Docker build process by creating reusable GitHub Actions workflows and refactoring existing workflows to use these new actions. 

### New Workflows:
* [`.github/workflows/build-docker-image.yaml`](diffhunk://#diff-2cca27db4975a5f28105256f69f1c5fc81cc8cf96ef05c32ec5a6ba318a31278R1-R120): Introduced a new reusable workflow for building Docker images with support for multiple platforms and caching.
* [`.github/workflows/merge-docker-images.yaml`](diffhunk://#diff-432f11cb6e41a1141e6a43e59a8aec53575d5c665389f26df8c565acfd93edb7R1-R71): Added a new reusable workflow for merging Docker image digests and pushing a manifest list.

### Refactored Workflows:
* [`.github/workflows/docker-build.yaml`](diffhunk://#diff-a894120de2d841cb7e1e40a5faee2225d8810cc3fe03ecd231b07322594fca1cL10-R41): Refactored to use the new `build-docker-image.yaml` and `merge-docker-images.yaml` workflows, simplifying the steps and reducing redundancy.

### Minor Changes:
* [`Dockerfile`](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557L1-R1): Minor formatting change to standardize the `FROM` instruction.

### Example Runs:
- [jedwards1230/pipelines/actions](https://github.com/jedwards1230/pipelines/actions/workflows/docker-build.yaml?query=branch%3Aconsolidate-docker)

### Potential Conflicts
- #300
  - These PRs should generally play well together, but one of the PRs will need to update their GH Actions to accommodate the other.