### PR TITLE
Add PIPELINES_ENV

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -130,9 +130,9 @@ fi
 
 
 # Start the server
-if [ "$ENV" = "production" ] || [ -z "$ENV" ]; then
+if [ "$PIPELINES_ENV" = "production" ] || [ -z "$PIPELINES_ENV" ]; then
     uvicorn main:app --host "$HOST" --port "$PORT" --forwarded-allow-ips '*'
 else
-    echo "Running in development mode"
+    echo "INFO:     Running in development mode"
     uvicorn main:app --host "$HOST" --port "$PORT" --forwarded-allow-ips '*' --reload
 fi

--- a/start.sh
+++ b/start.sh
@@ -130,4 +130,9 @@ fi
 
 
 # Start the server
-uvicorn main:app --host "$HOST" --port "$PORT" --forwarded-allow-ips '*'
+if [ "$ENV" = "production" ] || [ -z "$ENV" ]; then
+    uvicorn main:app --host "$HOST" --port "$PORT" --forwarded-allow-ips '*'
+else
+    echo "Running in development mode"
+    uvicorn main:app --host "$HOST" --port "$PORT" --forwarded-allow-ips '*' --reload
+fi


### PR DESCRIPTION
Enhance the `start.sh` script to recognize and utilize the `PIPELINES_ENV` environment variable as follows:

- **Development Mode**:
  - If `PIPELINES_ENV=development`, execute `uvicorn` with the `--reload` option. This will streamline the development process of Python pipelines by automatically reloading the server upon code changes.

- **Production Mode**:
  - If `PIPELINES_ENV=production` or if `PIPELINES_ENV` is unset or undefined, run `uvicorn` in its standard mode without the `--reload` option.

This change will accommodate both development and production environments seamlessly.