### PR TITLE
Let the pipeline know the valves have been updated after loading

### DIFF
--- a/main.py
+++ b/main.py
@@ -202,6 +202,8 @@ async def load_modules_from_directory(directory):
                             }
                             valves = ValvesModel(**combined_valves)
                             pipeline.valves = valves
+                            if hasattr(pipeline, "on_valves_updated"):
+                                await pipeline.on_valves_updated()
 
                             logging.info(f"Updated valves for module: {module_name}")
 


### PR DESCRIPTION
Some pipelines use dummy/default valves in the constructor. After a restart of the pipelines server, wrong information is used until an update of the valves is done via open-webui or the API.

So, after a (re)start of the pipelines server, it is wise to let the pipeline know that the valves might have changed.
This small fix does exactly that: call the on_valves_updated method in the load_modules_from_directory, similar to what is already present in the code after an update of the valves via the /{pipeline_id}/valves/update api.

Example pipeline (anthropic_manifold_pipeline):
```
class Pipeline:
    class Valves(BaseModel):
        ANTHROPIC_API_KEY: str = ""

    def __init__(self):
        ...
        self.valves = self.Valves(
            **{"ANTHROPIC_API_KEY": os.getenv("ANTHROPIC_API_KEY", "your-api-key-here")}
        )
        ...
        self.update_headers()

    def update_headers(self):
        self.headers = {
            'anthropic-version': '2023-06-01',
            'content-type': 'application/json',
            'x-api-key': self.valves.ANTHROPIC_API_KEY
        }

    async def on_valves_updated(self):
        self.update_headers()
```