### PR TITLE
Deleted chat_id from body

### DIFF
--- a/examples/filters/langfuse_filter_pipeline.py
+++ b/examples/filters/langfuse_filter_pipeline.py
@@ -110,6 +110,7 @@ class Pipeline:
         self.chat_generations[body["chat_id"]] = generation
         print(trace.get_trace_url())
 
+        del body["chat_id"]
         return body
 
     async def outlet(self, body: dict, user: Optional[dict] = None) -> dict:


### PR DESCRIPTION
prevent error 400: Unrecognized request argument supplied: chat_id it appears randomly when langfuse pipeline is active

![Captura desde 2024-12-27 18-57-00](https://github.com/user-attachments/assets/567c9182-333a-4c92-85f2-4f700fc9a8e6)
