### PR TITLE
Fix - install dependencies at docker image build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,8 @@ FROM python:3.11-slim-bookworm AS base
 ARG MINIMUM_BUILD
 ARG USE_CUDA
 ARG USE_CUDA_VER
+ARG PIPELINES_URLS
+ARG PIPELINES_REQUIREMENTS_PATH
 
 ## Basis ##
 ENV ENV=prod \
@@ -39,11 +41,25 @@ RUN if [ "$MINIMUM_BUILD" = "true" ]; then \
         uv pip install --system -r requirements.txt --no-cache-dir; \
     fi
 
+
+# Layer on for other components
+FROM base AS app
+
+ENV PIPELINES_URLS=${PIPELINES_URLS} \
+    PIPELINES_REQUIREMENTS_PATH=${PIPELINES_REQUIREMENTS_PATH}
+
 # Copy the application code
 COPY . .
+
+# Run a docker command if either PIPELINES_URLS or PIPELINES_REQUIREMENTS_PATH is not empty
+RUN if [ -n "$PIPELINES_URLS" ] || [ -n "$PIPELINES_REQUIREMENTS_PATH" ]; then \
+    echo "Running docker command with PIPELINES_URLS or PIPELINES_REQUIREMENTS_PATH"; \
+    ./start.sh --mode setup; \
+    fi
 
 # Expose the port
 ENV HOST="0.0.0.0"
 ENV PORT="9099"
 
+# if we already installed the requirements on build, we can skip this step on run
 ENTRYPOINT [ "bash", "start.sh" ]

--- a/README.md
+++ b/README.md
@@ -101,6 +101,38 @@ Get started with Pipelines in a few easy steps:
 
 Once the server is running, set the OpenAI URL on your client to the Pipelines URL. This unlocks the full capabilities of Pipelines, integrating any Python library and creating custom workflows tailored to your needs.
 
+### Advanced Docker Builds
+If you create your own pipelines, you can install them when the Docker image is built.  For example,
+create a bash script with the snippet below to collect files from a path, add them as install URLs, 
+and build the Docker image with the new pipelines automatically installed.
+
+NOTE: The pipelines module will still attempt to install any package dependencies found at in your
+file headers at start time, but they will not be downloaded again.
+
+```sh
+# build in the specific pipelines
+PIPELINE_DIR="pipelines-custom"
+# assuming the above directory is in your source repo and not skipped by `.dockerignore`, it will get copied to the image
+PIPELINE_PREFIX="file:///app"
+
+# retrieve all the sub files
+export PIPELINES_URLS=
+for file in "$PIPELINE_DIR"/*; do
+    if [[ -f "$file" ]]; then
+        if [[ "$file" == *.py ]]; then
+            if [ -z "$PIPELINES_URLS" ]; then
+                PIPELINES_URLS="$PIPELINE_PREFIX/$file"
+            else
+                PIPELINES_URLS="$PIPELINES_URLS;$PIPELINE_PREFIX/$file"
+            fi
+        fi
+    fi
+done
+echo "New Custom Install Pipes: $PIPELINES_URLS"
+
+docker build --build-arg PIPELINES_URLS=$PIPELINES_URLS --build-arg MINIMUM_BUILD=true -f Dockerfile .
+```
+
 ## 📂 Directory Structure and Examples
 
 The `/pipelines` directory is the core of your setup. Add new modules, customize existing ones, and manage your workflows here. All the pipelines in the `/pipelines` directory will be **automatically loaded** when the server launches.


### PR DESCRIPTION
- refine `start.sh` for pre-install capability to be used in docker image build
- update README for advanced docker build usage
- why: this will prevent you from hitting package install repo (which may be net-blocked in corporate env) when trying to install special packages that your custom pipelines have listed