### PR TITLE
Fix/testing - add basic tests (pytest + flake8) with minor reconfig

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -4,7 +4,11 @@
 .gitignore
 .github
 Dockerfile
+blueprints
 examples
+tests
+coverage
+data
 docs
 *.md
 dev.sh

--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,7 @@ __pycache__
 
 /litellm
 
-
+coverage
 pipelines/*
 !pipelines/.gitignore
 .DS_Store

--- a/Dockerfile
+++ b/Dockerfile
@@ -43,7 +43,7 @@ RUN if [ "$MINIMUM_BUILD" = "true" ]; then \
     else \
         uv pip install --system -r requirements.txt --no-cache-dir; \
     fi
-RUN if [ "$USE_TEST" != "false" ]; then \
+RUN if [ -n "$USE_TEST" ] && [ "$USE_TEST" != "false" ]; then \
     uv pip install --system -r requirements-test.txt --no-cache-dir; \
 fi
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,11 +4,15 @@ FROM python:3.11-slim-bookworm AS base
 ARG MINIMUM_BUILD
 ARG USE_CUDA
 ARG USE_CUDA_VER
+ARG USE_TEST=false
+ARG PIPELINES_URLS=
+ARG PIPELINES_REQUIREMENTS_PATH=
 
 ## Basis ##
 ENV ENV=prod \
     PORT=9099 \
     # pass build args to the build
+    USE_TEST=${USE_TEST} \
     MINIMUM_BUILD=${MINIMUM_BUILD} \
     USE_CUDA_DOCKER=${USE_CUDA} \
     USE_CUDA_DOCKER_VER=${USE_CUDA_VER}
@@ -25,6 +29,7 @@ WORKDIR /app
 # Install Python dependencies
 COPY ./requirements.txt .
 COPY ./requirements-minimum.txt .
+COPY ./requirements-test.txt .
 RUN pip3 install uv
 RUN if [ "$MINIMUM_BUILD" != "true" ]; then \
         if [ "$USE_CUDA_DOCKER" = "true" ]; then \
@@ -38,6 +43,15 @@ RUN if [ "$MINIMUM_BUILD" = "true" ]; then \
     else \
         uv pip install --system -r requirements.txt --no-cache-dir; \
     fi
+RUN if [ "$USE_TEST" != "false" ]; then \
+    uv pip install --system -r requirements-test.txt --no-cache-dir; \
+fi
+
+# Layer on for other components
+FROM base AS app
+
+ENV PIPELINES_URLS=${PIPELINES_URLS} \
+    PIPELINES_REQUIREMENTS_PATH=${PIPELINES_REQUIREMENTS_PATH}
 
 # Copy the application code
 COPY . .
@@ -46,4 +60,5 @@ COPY . .
 ENV HOST="0.0.0.0"
 ENV PORT="9099"
 
-ENTRYPOINT [ "bash", "start.sh" ]
+# we use a CMD so that it can be overriden by other tests on the container
+CMD [ "bash", "start.sh" ]

--- a/README.md
+++ b/README.md
@@ -101,6 +101,24 @@ Get started with Pipelines in a few easy steps:
 
 Once the server is running, set the OpenAI URL on your client to the Pipelines URL. This unlocks the full capabilities of Pipelines, integrating any Python library and creating custom workflows tailored to your needs.
 
+### Testing the Pipelines Server
+
+To be updated as the project matures, testing for coverage and basic functionality is included in the 
+tests directory.  You can build a docker image and start a test with the following commands.
+
+```sh
+# build the image
+docker build -t pipelines:dev --build-arg USE_TEST=$USE_TEST --build-arg MINIMUM_BUILD=true -f Dockerfile .
+
+# prep coverage directory
+mkdir -p `pwd`/coverage
+docker run --rm -v "`pwd`/coverage:/coverage" -v "`pwd`/tests:/app/tests" pipelines:dev pytest --cov=/app  --cov-report html:/coverage/coverage.html --cov-report=xml:/coverage/coverage.xml tests
+
+# run flake8 for syntax suggestions
+SELECT_CLAUSE="--ignore=E501,E121,E128,E124,E123"
+docker run --rm -v "`pwd`/coverage:/coverage" pipelines:dev flake8 /app --exclude .venv --count $SELECT_CLAUSE --show-source --statistics --output-file=/coverage/flake8.txt --color=never --exit-zero
+```
+
 ## 📂 Directory Structure and Examples
 
 The `/pipelines` directory is the core of your setup. Add new modules, customize existing ones, and manage your workflows here. All the pipelines in the `/pipelines` directory will be **automatically loaded** when the server launches.

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,0 +1,3 @@
+pytest
+flake8
+pytest-cov

--- a/tests/test_endpoints.py
+++ b/tests/test_endpoints.py
@@ -1,0 +1,20 @@
+import sys
+import pytest
+from pathlib import Path
+import json
+from unittest.mock import patch, mock_open
+from fastapi.testclient import TestClient
+
+# need to add the parent directory to the path to import the main module
+sys.path.append(str(Path(__file__).resolve().parent.parent))
+from main import app
+
+# using the app object from the main module
+client = TestClient(app)
+
+def test_get_status():
+    response = client.get("/v1")
+    assert response.status_code == 200
+    assert response.json() == {"status": True}
+
+# TODO: check other endpoints from the client -- both mocked and URL-based


### PR DESCRIPTION
- as we start to add more functionality, want an automated placeholder for tests
- no impact to existing code base
- when we switch to using `pyproject.toml` can update / merge the requirements doc correctly