### PR TITLE
fix: Get usage from usage field in message response body

### DIFF
--- a/examples/filters/langfuse_filter_pipeline.py
+++ b/examples/filters/langfuse_filter_pipeline.py
@@ -239,10 +239,10 @@ class Pipeline:
         # Extract usage if available
         usage = None
         if assistant_message_obj:
-            info = assistant_message_obj.get("info", {})
-            if isinstance(info, dict):
-                input_tokens = info.get("prompt_eval_count") or info.get("prompt_tokens")
-                output_tokens = info.get("eval_count") or info.get("completion_tokens")
+            message_usage = assistant_message_obj.get("usage", {})
+            if isinstance(message_usage, dict):
+                input_tokens = message_usage.get("prompt_eval_count") or message_usage.get("prompt_tokens")
+                output_tokens = message_usage.get("eval_count") or message_usage.get("completion_tokens")
                 if input_tokens is not None and output_tokens is not None:
                     usage = {
                         "input": input_tokens,


### PR DESCRIPTION
### Description

- This retrieves usage data if it exists from the usage field as passed by the chatCompleted handler in OpenWebUI as implemented in open-webui/open-webui#10711. I'm assuming this was functional at one point because this pipeline seems to assume it will be available but usage would never be passed to the outlet as code is currently. This filter is looking for usage in the info field but this doesn't seem consistent with OpenAI or other models so I left it as usage.

### Fixed

- This retrieves usage data if it exists in the usage field of the response body which allows it to be processed in filter pipeline outlet function.
