### PR TITLE
Fix: Error: int() argument must be a string, a bytes-like object or a…

### DIFF
--- a/examples/pipelines/providers/anthropic_manifold_pipeline.py
+++ b/examples/pipelines/providers/anthropic_manifold_pipeline.py
@@ -173,6 +173,7 @@ class Pipeline:
                 # Allow users to input an integer value representing budget tokens
                 if (
                     not budget_tokens
+                    and reasoning_effort is not None
                     and reasoning_effort not in REASONING_EFFORT_BUDGET_TOKEN_MAP.keys()
                 ):
                     try:


### PR DESCRIPTION
The pipeline will throw an uncaught exception whenever `reasoning_effort` is `None` because it is a `TypeError` and the try/catch block only catches `ValueError`

This PR fixes it by checking if the value is None and skipping the int conversion step entirely if it is.

The error is easy to reproduce:
1. Generate a response with the model and start a conversation
2. Open the Chat Controls sidebar, in Advanced Params click on Reasoning Effort so it is set to the default string of "medium"
3. Generate another response, this time it will have reasoning
4. Click on Advanced Params > Reasoning Effort > Custom, closing the textbox and returning the button to "Default"
5. Generate another response
6. `Error: int() argument must be a string, a bytes-like object or a real number, not 'NoneType'`