### PR TITLE
add log-level via env to pipelines

### DIFF
--- a/main.py
+++ b/main.py
@@ -39,6 +39,10 @@ PIPELINES = {}
 PIPELINE_MODULES = {}
 PIPELINE_NAMES = {}
 
+#Add GLOBAL_LOG_LEVEL for Pipeplines
+log_level = os.getenv('GLOBAL_LOG_LEVEL', 'INFO').upper()
+logging.basicConfig(level=LOG_LEVELS[log_level])
+
 
 def get_all_pipelines():
     pipelines = {}


### PR DESCRIPTION
currently there is no option to define the loglevel for pipelines by setting a global env like in open-webui...

this improvement should fix this: GLOBAL_LOG_LEVEL