### PR TITLE
Remove LOG_LEVELs cause this dictionary is not global available

### DIFF
--- a/main.py
+++ b/main.py
@@ -41,8 +41,8 @@ PIPELINE_NAMES = {}
 
 #Add GLOBAL_LOG_LEVEL for Pipeplines
 log_level = os.getenv('GLOBAL_LOG_LEVEL', 'INFO').upper()
-logging.basicConfig(level=LOG_LEVELS[log_level])
-
+numeric_level = getattr(logging, log_level, logging.INFO)
+logging.basicConfig(level=numeric_level)
 
 def get_all_pipelines():
     pipelines = {}


### PR DESCRIPTION
hi @tjbck, by mistake my i had an "global" log_levels dictonary but in the main.py this isn´t available -> which causes, that this fix works on my env but maybo not on others, thats why i removed the "log_levels" and replaced it, now this should work fine for everyone. 
@malvex thx for this info!