### PR TITLE
Feat: Use session_id to trace temporary chats with Langfuse

### DIFF
--- a/examples/filters/langfuse_filter_pipeline.py
+++ b/examples/filters/langfuse_filter_pipeline.py
@@ -1,7 +1,7 @@
 """
 title: Langfuse Filter Pipeline
 author: open-webui
-date: 2025-03-28
+date: 2025-06-16
 version: 1.7
 license: MIT
 description: A filter pipeline that uses Langfuse.
@@ -126,6 +126,12 @@ class Pipeline:
 
         metadata = body.get("metadata", {})
         chat_id = metadata.get("chat_id", str(uuid.uuid4()))
+
+        # Handle temporary chats
+        if chat_id == "local":
+            session_id = metadata.get("session_id")
+            chat_id = f"temporary-session-{session_id}"
+
         metadata["chat_id"] = chat_id
         body["metadata"] = metadata
 
@@ -233,6 +239,12 @@ class Pipeline:
         self.log(f"Outlet function called with body: {body}")
 
         chat_id = body.get("chat_id")
+
+        # Handle temporary chats
+        if chat_id == "local":
+            session_id = body.get("session_id")
+            chat_id = f"temporary-session-{session_id}"
+
         metadata = body.get("metadata", {})
         # Defaulting to 'llm_response' if no task is provided
         task_name = metadata.get("task", "llm_response")


### PR DESCRIPTION
Currently, all temporary chats are assigned the chat_id value "local." Due to the existing implementation in the [langfuse_filter_pipeline.py](https://github.com/open-webui/pipelines/blob/adec65727e69cfd4e0a6ea30cf85ed0443f4a89a/examples/filters/langfuse_filter_pipeline.py), all temporary chats from different users are grouped into a single trace labeled "chat:local." This results in inaccurate trace data and incorrect user usage statistics.

To resolve this, I propose using the session_id as the trace name whenever chat_id is set to "local."

I have tested this approach in a local environment, and it functions as expected.

Discussions:
- https://github.com/open-webui/open-webui/discussions/14972
- https://github.com/open-webui/open-webui/discussions/11556