### PR TITLE
fix: sample rag/text_to_sql_pipeline psql port to str

### DIFF
--- a/examples/pipelines/rag/text_to_sql_pipeline.py
+++ b/examples/pipelines/rag/text_to_sql_pipeline.py
@@ -40,7 +40,7 @@ class Pipeline:
             **{
                 "pipelines": ["*"],                                                           # Connect to all pipelines
                 "DB_HOST": os.getenv("DB_HOST", "http://localhost"),                     # Database hostname
-                "DB_PORT": os.getenv("DB_PORT", 5432),                                        # Database port 
+                "DB_PORT": os.getenv("DB_PORT", "5432"),                                        # Database port 
                 "DB_USER": os.getenv("DB_USER", "postgres"),                                  # User to connect to the database with
                 "DB_PASSWORD": os.getenv("DB_PASSWORD", "password"),                          # Password to connect to the database with
                 "DB_DATABASE": os.getenv("DB_DATABASE", "postgres"),                          # Database to select on the DB instance


### PR DESCRIPTION
I got error on load the file.
I think it's because DB_PORT defined in class Valves(BaseModel) set to str, but in __init__ the config set to integer.
