### PR TITLE
feat: add Stellar Memory filter pipeline

### DIFF
--- a/examples/filters/stellar_memory_filter_pipeline.py
+++ b/examples/filters/stellar_memory_filter_pipeline.py
@@ -1,0 +1,106 @@
+"""
+title: Stellar Memory Filter
+author: sangjun0000
+date: 2026-03-28
+version: 2.0.0
+license: MIT
+description: A filter that automatically recalls relevant memories before each request and stores important responses using Stellar Memory — a local AI memory system with celestial mechanics metaphor.
+requirements: pydantic, requests
+"""
+
+from typing import List, Optional
+from pydantic import BaseModel
+import requests
+
+
+class Pipeline:
+    class Valves(BaseModel):
+        STM_URL: str = "http://localhost:21547"
+        STM_PROJECT: str = ""
+        RECALL_LIMIT: int = 5
+        AUTO_REMEMBER: bool = True
+
+    def __init__(self):
+        self.name = "Stellar Memory"
+        self.valves = self.Valves()
+
+    async def on_startup(self):
+        pass
+
+    async def on_shutdown(self):
+        pass
+
+    def _project(self) -> str:
+        return self.valves.STM_PROJECT.strip() or "default"
+
+    def _extract_last_message(self, messages: list, role: str) -> Optional[str]:
+        for msg in reversed(messages):
+            if msg.get("role") == role:
+                content = msg.get("content", "")
+                if isinstance(content, list):
+                    parts = [p.get("text", "") for p in content if p.get("type") == "text"]
+                    return " ".join(parts).strip() or None
+                return content.strip() or None
+        return None
+
+    async def inlet(self, body: dict, user: Optional[dict] = None) -> dict:
+        messages = body.get("messages", [])
+        query = self._extract_last_message(messages, "user")
+        if not query:
+            return body
+
+        try:
+            resp = requests.get(
+                f"{self.valves.STM_URL}/api/memories/search",
+                params={"q": query, "limit": self.valves.RECALL_LIMIT, "project": self._project()},
+                timeout=3,
+            )
+            resp.raise_for_status()
+            data = resp.json()
+            memories = data if isinstance(data, list) else data.get("memories", [])
+        except Exception:
+            return body
+
+        if not memories:
+            return body
+
+        lines = ["[Stellar Memory — Relevant context]"]
+        for m in memories:
+            summary = m.get("summary") or m.get("content", "")[:80]
+            mem_type = m.get("type", "context")
+            lines.append(f"- {summary} ({mem_type})")
+        injection = "\n".join(lines)
+
+        if messages and messages[0].get("role") == "system":
+            messages[0]["content"] = injection + "\n\n" + messages[0]["content"]
+        else:
+            messages.insert(0, {"role": "system", "content": injection})
+
+        body["messages"] = messages
+        return body
+
+    async def outlet(self, body: dict, user: Optional[dict] = None) -> dict:
+        if not self.valves.AUTO_REMEMBER:
+            return body
+
+        messages = body.get("messages", [])
+        text = self._extract_last_message(messages, "assistant")
+        if not text or len(text) < 100:
+            return body
+
+        try:
+            requests.post(
+                f"{self.valves.STM_URL}/api/memories",
+                json={
+                    "content": text[:500],
+                    "summary": text[:80],
+                    "type": "observation",
+                    "tags": ["openwebui", "auto"],
+                    "project": self._project(),
+                },
+                timeout=3,
+            )
+        except Exception:
+            pass
+
+        return body


### PR DESCRIPTION
## Stellar Memory Filter Pipeline

Adds a filter pipeline that integrates [Stellar Memory](https://github.com/sangjun0000/stellar-memory-core) — a local AI memory system — with OpenWebUI.

### What it does

- **inlet**: Before each request, searches Stellar Memory for relevant context and prepends it to the system prompt automatically
- **outlet**: After each response, optionally saves the assistant's reply as a new memory (auto-growing knowledge base)

### Requirements

- Stellar Memory running locally: `npx stellar-memory api` (starts REST API on port 21547)
- No cloud service required — fully local and private

### Configuration (Valves)

| Valve | Default | Description |
|-------|---------|-------------|
| `STM_URL` | `http://localhost:21547` | Stellar Memory API URL |
| `STM_PROJECT` | `""` (auto: "default") | Project namespace for memory isolation |
| `RECALL_LIMIT` | `5` | Max memories to inject per request |
| `AUTO_REMEMBER` | `True` | Auto-save assistant responses as memories |

### Setup

1. Install Stellar Memory: `npm install -g stellar-memory && npm run init`
2. Start the API: `npx stellar-memory api`
3. Upload this pipeline in OpenWebUI → Admin → Pipelines
4. Set `STM_URL` in pipeline settings (Docker users: use `http://host.docker.internal:21547`)